### PR TITLE
CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+# Flake8 cannot be configured in pyproject.toml :(
+# https://github.com/PyCQA/flake8/issues/234
+
+[flake8]
+max-line-length = 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ on:
 jobs:
   ci:
     # https://github.com/questionpy-org/.github
-    uses: questionpy-org/.github/.github/workflows/python-ci.yml@feature/3/reusable-ci
+    uses: questionpy-org/.github/.github/workflows/python-ci.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: "CI"
+
+on:
+  push:
+  pull_request:
+    # We don't run on PR synchronize, because that would duplicate the push-Build
+    types:
+      - opened
+
+jobs:
+  ci:
+    # https://github.com/questionpy-org/.github
+    uses: questionpy-org/.github/.github/workflows/python-ci.yml@feature/3/reusable-ci

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+printf -- 'running flake8 \n'
+flake8 questionpy tests
+
+printf -- 'running pylint \n'
+pylint questionpy tests
+
+printf -- 'running pytest \n'
+pytest tests
+
+printf -- 'running mypy \n'
+mypy questionpy tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[tool.pytest.ini_options]
+# https://github.com/pytest-dev/pytest-asyncio#auto-mode
+asyncio_mode = "auto"
+addopts = "--cov --cov-config=pyproject.toml --cov-branch --cov-report term:skip-covered"
+
+
+[tool.coverage.run]
+omit = ["tests/*"]
+
+
+[tool.pylint]
+
+[tool.pylint.MAIN]
+
+extension-pkg-allow-list = "pydantic"
+# pylint_pytest removes some false positives when checking tests
+load-plugins = "pylint_pytest"
+
+fail-on = ["E", "F"]
+fail-under = 8
+
+[tool.pylint.REPORTS]
+output-format = "colorized"
+
+[tool.pylint."MESSAGES CONTROL"]
+disable = ["missing-module-docstring", "missing-class-docstring", "missing-function-docstring"]
+enable = ""
+
+[tool.pylint.FORMAT]
+
+expected-line-ending-format = "LF"
+indent-after-paren = 4
+indent-string = "    "
+max-line-length = 120
+
+
+[tool.mypy]
+plugins = "pydantic.mypy"
+disallow_untyped_defs = true
+strict_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ load-plugins = "pylint_pytest"
 fail-on = ["E", "F"]
 fail-under = 8
 
+[tool.pylint.BASIC]
+# Allow these well-known names despite usual naming conventions
+good-names = ["i", "j", "k", "e", "ex", "_"]
+
 [tool.pylint.REPORTS]
 output-format = "colorized"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,4 @@ max-line-length = 120
 plugins = "pydantic.mypy"
 disallow_untyped_defs = true
 strict_optional = true
+show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ addopts = "--cov --cov-config=pyproject.toml --cov-branch --cov-report term:skip
 
 
 [tool.coverage.run]
-omit = ["tests/*"]
+branch = true
+source = ["questionpy"]
 
 
 [tool.pylint]

--- a/questionpy/__init__.py
+++ b/questionpy/__init__.py
@@ -1,0 +1,4 @@
+# This is a pkgutil-style namespace package, because PyLint does not support PEP 420 native namespace packages :(
+# https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
+# https://github.com/PyCQA/pylint/issues/2862
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/questionpy/sdk/__main__.py
+++ b/questionpy/sdk/__main__.py
@@ -6,7 +6,7 @@ from questionpy.sdk.logging import init_logging
 
 
 @click.group()
-def cli():
+def cli() -> None:
     init_logging()
 
 

--- a/questionpy/sdk/__main__.py
+++ b/questionpy/sdk/__main__.py
@@ -1,4 +1,4 @@
-import click as click
+import click
 
 from questionpy.sdk.commands.package import package
 from questionpy.sdk.commands.run import run

--- a/questionpy/sdk/commands/package.py
+++ b/questionpy/sdk/commands/package.py
@@ -11,13 +11,11 @@ from questionpy.sdk.manifest import Manifest
 
 log = logging.getLogger(__name__)
 
-package: click.Command
-
 
 @click.command()
 @click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
 @click.option("--manifest", "-m", "manifest_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
-def package(source: Path, manifest_path: Optional[Path]):
+def package(source: Path, manifest_path: Optional[Path]) -> None:
     out_path = source.with_suffix(".qpy")
 
     if not manifest_path:
@@ -40,7 +38,7 @@ def package(source: Path, manifest_path: Optional[Path]):
         out_file.writestr("qpy_manifest.yml", manifest.yaml())
 
 
-def install_dependencies(target: ZipFile, manifest_path: Path, manifest: Manifest):
+def install_dependencies(target: ZipFile, manifest_path: Path, manifest: Manifest) -> None:
     if isinstance(manifest.requirements, str):
         # treat as a relative reference to a requirements.txt and read those
         pip_args = ["-r", str(manifest_path.parent / manifest.requirements)]

--- a/questionpy/sdk/commands/package.py
+++ b/questionpy/sdk/commands/package.py
@@ -5,7 +5,7 @@ from tempfile import TemporaryDirectory
 from typing import Optional
 from zipfile import ZipFile
 
-import click as click
+import click
 
 from questionpy.sdk.manifest import Manifest
 
@@ -31,10 +31,10 @@ def package(source: Path, manifest_path: Optional[Path]) -> None:
 
         for source_file in source.glob("**/*.py"):
             path_in_pkg = source_file.relative_to(source)
-            log.info(f"{path_in_pkg}: {source_file}")
+            log.info("%s: %s", path_in_pkg, source_file)
             out_file.write(source_file, path_in_pkg)
 
-        log.info(f"qpy_manifest.yml: {manifest}")
+        log.info("qpy_manifest.yml: %s", manifest)
         out_file.writestr("qpy_manifest.yml", manifest.yaml())
 
 
@@ -54,5 +54,5 @@ def install_dependencies(target: ZipFile, manifest_path: Path, manifest: Manifes
 
         for file in Path(tempdir).glob("**/*"):
             path_in_pkg = file.relative_to(tempdir)
-            log.info(f"{path_in_pkg}: {file}")
+            log.info("%s: %s", path_in_pkg, file)
             target.write(file, path_in_pkg)

--- a/questionpy/sdk/commands/run.py
+++ b/questionpy/sdk/commands/run.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from importlib import import_module
 from pathlib import Path
@@ -9,13 +10,13 @@ from questionpy.sdk.manifest import Manifest
 from questionpy.sdk.qtype import QuestionType
 from questionpy.sdk.runtime import QPyRuntime
 
-run: click.Command
+log = logging.getLogger(__name__)
 
 
 @click.command()
 @click.argument("package", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("-p", "--pretty", is_flag=True, show_default=True, default=False, help="Output indented JSON.")
-def run(package: Path, pretty: bool):
+def run(package: Path, pretty: bool) -> None:
     with ZipFile(package) as package_file:
         manifest = Manifest.parse_raw(package_file.read("qpy_manifest.yml"))
 
@@ -25,5 +26,9 @@ def run(package: Path, pretty: bool):
     finally:
         sys.path.remove(str(package))
 
-    runtime = QPyRuntime(manifest, QuestionType.__subclasses__()[0], pretty=pretty)
+    if QuestionType.implementation is None:
+        log.fatal("The package '%s' does not contain an implementation of QuestionType", package)
+        exit(1)
+
+    runtime = QPyRuntime(manifest, QuestionType.implementation, pretty=pretty)
     runtime.run()

--- a/questionpy/sdk/commands/run.py
+++ b/questionpy/sdk/commands/run.py
@@ -8,7 +8,7 @@ import click
 
 from questionpy.sdk.manifest import Manifest
 from questionpy.sdk.qtype import QuestionType
-from questionpy.sdk.runtime import QPyRuntime
+from questionpy.sdk.runtime import run_qtype
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +28,6 @@ def run(package: Path, pretty: bool) -> None:
 
     if QuestionType.implementation is None:
         log.fatal("The package '%s' does not contain an implementation of QuestionType", package)
-        exit(1)
+        sys.exit(1)
 
-    runtime = QPyRuntime(manifest, QuestionType.implementation, pretty=pretty)
-    runtime.run()
+    run_qtype(manifest, QuestionType.implementation, pretty=pretty)

--- a/questionpy/sdk/logging.py
+++ b/questionpy/sdk/logging.py
@@ -2,5 +2,5 @@ import logging
 import sys
 
 
-def init_logging():
+def init_logging() -> None:
     logging.basicConfig(level=logging.INFO, stream=sys.stderr)

--- a/questionpy/sdk/manifest.py
+++ b/questionpy/sdk/manifest.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional, Set, Union
 
-from pydantic import BaseModel
-from pydantic_yaml import YamlModelMixin, YamlStrEnum
+from pydantic_yaml import YamlModel, YamlStrEnum
 
 
 class PackageType(YamlStrEnum):
@@ -9,7 +8,7 @@ class PackageType(YamlStrEnum):
     LIBRARY = "LIBRARY"
 
 
-class Manifest(YamlModelMixin, BaseModel):
+class Manifest(YamlModel):
     short_name: str
     version: str
     api_version: str

--- a/questionpy/sdk/qtype.py
+++ b/questionpy/sdk/qtype.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 
 class MissingOptionError(Exception):
     def __init__(self, name: str):
+        super().__init__(f"Question option '{name}' was required but not provided")
         self.name = name
 
 
@@ -23,7 +24,8 @@ class QuestionType(ABC):
         QuestionType.implementation = cls
 
     @abstractmethod
-    def render_edit_form(self, form: Form) -> None: ...
+    def render_edit_form(self, form: Form) -> None:
+        pass
 
     def validate_options(self, options: Dict[str, Any]) -> Dict[str, Any]:
         return options

--- a/questionpy/sdk/qtype.py
+++ b/questionpy/sdk/qtype.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Type
 
 from questionpy.sdk.manifest import Manifest
 from questionpy.sdk.model.form import Form
@@ -14,10 +14,13 @@ class MissingOptionError(Exception):
 
 
 class QuestionType(ABC):
-    manifest: Manifest
+    implementation: Optional[Type["QuestionType"]] = None
 
     def __init__(self, manifest: Manifest):
         self.manifest = manifest
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        QuestionType.implementation = cls
 
     @abstractmethod
     def render_edit_form(self, form: Form) -> None: ...

--- a/questionpy/sdk/runtime.py
+++ b/questionpy/sdk/runtime.py
@@ -11,27 +11,21 @@ from questionpy.sdk.server import QPyPackageServer
 log = logging.getLogger(__name__)
 
 
-class QPyRuntime:
-    def __init__(self, manifest: Manifest, qtype: Type[QuestionType], *, pretty: bool = False):
-        self.manifest = manifest
-        self.qtype = qtype
-        self.pretty = pretty
+def run_qtype(manifest: Manifest, qtype: Type[QuestionType], *, pretty: bool = False) -> None:
+    qtype_instance = qtype(manifest=manifest)
 
-    def run(self) -> None:
-        qtype_instance = self.qtype(manifest=self.manifest)
+    log.info("Running question type '%s:%s' with manifest '%s'",
+             qtype.__module__, qtype.__name__, manifest)
 
-        log.info("Running question type '%s:%s' with manifest '%s'",
-                 self.qtype.__module__, self.qtype.__name__, self.manifest)
-
-        server = QPyPackageServer(sys.stdin, sys.stdout, pretty=self.pretty)
-        for message in server:
-            if isinstance(message, PingMessage):
-                server.send(PongMessage())
-            elif isinstance(message, RenderEditForm):
-                form = Form()
-                qtype_instance.render_edit_form(form)
-                server.send(RenderEditForm.Response(form=form))
-            elif isinstance(message, ValidateOptionsMessage):
-                server.send(ValidateOptionsMessage.Response(state=qtype_instance.validate_options(message.options)))
-            else:
-                log.error("Unsupported message type: %s", type(message).__name__)
+    server = QPyPackageServer(sys.stdin, sys.stdout, pretty=pretty)
+    for message in server:
+        if isinstance(message, PingMessage):
+            server.send(PongMessage())
+        elif isinstance(message, RenderEditForm):
+            form = Form()
+            qtype_instance.render_edit_form(form)
+            server.send(RenderEditForm.Response(form=form))
+        elif isinstance(message, ValidateOptionsMessage):
+            server.send(ValidateOptionsMessage.Response(state=qtype_instance.validate_options(message.options)))
+        else:
+            log.error("Unsupported message type: %s", type(message).__name__)

--- a/questionpy/sdk/server.py
+++ b/questionpy/sdk/server.py
@@ -16,7 +16,7 @@ class QPyPackageServer(Iterator[Message]):
         self.write_stream = write_stream
         self.pretty = pretty
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Message]:
         return self
 
     def __next__(self) -> Message:
@@ -25,7 +25,8 @@ class QPyPackageServer(Iterator[Message]):
             line = self._read_next_line()
 
             try:
-                message = pydantic.parse_raw_as(Message, line)
+                # Mypy wrongly infers the type of Message to object for some reason, leading to a false positive here.
+                message = pydantic.parse_raw_as(Message, line)  # type: ignore[arg-type]
             except (JSONDecodeError, ValidationError) as e:
                 log.error("Received invalid message, ignoring", exc_info=e)
                 continue

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+pytest==7.1.2
+pytest-aiohttp==1.0.4
+pytest-md==0.2.0
+pytest-cov==3.0.0
+pylint==2.14.2
+pylint-pytest==1.1.2
+mypy==0.961
+flake8==4.0.1

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_nothing() -> None:
-    pass

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_nothing() -> None:
+    pass

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,36 @@
+from io import StringIO
+
+import pytest
+
+from questionpy.sdk.model.messages import PingMessage
+from questionpy.sdk.server import QPyPackageServer
+
+
+def create_server(in_text: str) -> QPyPackageServer:
+    in_stream = StringIO(in_text)
+    out_stream = StringIO()
+    return QPyPackageServer(in_stream, out_stream)
+
+
+def test_read_message() -> None:
+    server = create_server('{ "kind": "ping" }')
+    assert next(server) == PingMessage()
+
+
+@pytest.mark.parametrize("in_text", ("", "\n", " \t", " \t\n"))
+def test_read_ignore(in_text: str) -> None:
+    server = create_server(in_text)
+    with pytest.raises(StopIteration):
+        # We expect the server to ignore the input, skipping straight to EOF
+        next(server)
+
+
+# should ignore like test_read_ignore, but also log
+@pytest.mark.parametrize("in_text", ("not json at all\n", '{ "kind": "unknown_kind" }\n'))
+def test_read_invalid(in_text: str, caplog: pytest.LogCaptureFixture) -> None:
+    server = create_server(in_text)
+    with pytest.raises(StopIteration):
+        # We expect the server to ignore the input, skipping straight to EOF
+        next(server)
+
+    assert any("invalid message" in record.message for record in caplog.records)


### PR DESCRIPTION
* Ich habe den questionpy-server workflow zu https://github.com/questionpy-org/.github kopiert. Das ist jetzt ein [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows). Für GitHub actions ist der Name des Repos, in dem der reusable workflow liegt, egal. Das spezielle `.github`-Repo kann aber auch einige andere Metadaten enthalten (Issue Templates, Org-README, etc.), deshalb habe ich die Workflows da rein gemacht.
* Zwei unscheinbare Änderungen an der pyproject.toml habe ich gemacht. Würde ich auch beides gleich in questionpy-server übertragen. Leider scheint es nicht (einfach) möglich zu sein, diese Konfigurationen zentral zu halten :(
  * `good-names` erlaubt explizit u.a. die Variablennamen `i`, `e` und `_`. (Da die eine ziemlich klare Bedeutung haben, auch wenn sie nur ein Zeichen lang sind)
  * pytest bzw. coverage.py bemerkt jetzt auch, dass module unter `questionpy` während der Tests gar nicht importiert werden, und verpasst denen 0%, statt sie zu ignorieren
* Kleinere Refactorings sind noch mit dabei, um mypy und pylint glücklich zu machen.

Closes #3 