### PR TITLE
#5: Einfache Validierung von Optionen

### DIFF
--- a/example/main.py
+++ b/example/main.py
@@ -9,9 +9,9 @@ class ExampleQuestionType(QuestionType):
     def render_edit_form(self) -> Form:
         return Form(
             general=[
-                TextElement(label="A static text element", name="", text="And this is its content."),
+                TextElement(label="A static text element", text="And this is its content."),
                 TextInputElement(label="A text input", name="text_input"),
-                ButtonElement(label="A button", name="button"),
+                ButtonElement(label="A button"),
                 CheckboxElement(label="A single checkbox", name="single_checkbox"),
                 CheckboxGroupElement(checkboxes=[
                     CheckboxElement(label="A checkbox inside a group", name="grouped_checkbox")

--- a/example/main.py
+++ b/example/main.py
@@ -6,26 +6,27 @@ from questionpy.form import ButtonElement, CheckboxElement, CheckboxGroupElement
 
 class ExampleQuestionType(QuestionType):
 
-    def render_edit_form(self, form: Form) -> None:
-        form.general += [
-            TextElement(label="A static text element", name="", text="And this is its content."),
-            TextInputElement(label="A text input", name="text_input"),
-            ButtonElement(label="A button", name="button"),
-            CheckboxElement(label="A single checkbox", name="single_checkbox"),
-            CheckboxGroupElement(checkboxes=[
-                CheckboxElement(label="A checkbox inside a group", name="grouped_checkbox")
-            ]),
-            RadioGroupElement(label="A radio group", name="radio", buttons=[
-                RadioGroupElement.Option(label="Radio Button 1", value="1"),
-                RadioGroupElement.Option(label="Radio Button 2", value="2")
-            ]),
-            SelectElement(label="A select box", name="select", options=[
-                SelectElement.Option(label="Option 1", value="1"),
-                SelectElement.Option(label="Option 2", value="2", selected=True)
-            ]),
-            HiddenElement(name="hidden", value="ill be sent along with the form")
-        ]
-
-        form.sections += FormSection(header="Custom Section", elements=[
-            TextInputElement(label="I'm inside a section!", name="text_input_in_section")
-        ])
+    def render_edit_form(self) -> Form:
+        return Form(
+            general=[
+                TextElement(label="A static text element", name="", text="And this is its content."),
+                TextInputElement(label="A text input", name="text_input"),
+                ButtonElement(label="A button", name="button"),
+                CheckboxElement(label="A single checkbox", name="single_checkbox"),
+                CheckboxGroupElement(checkboxes=[
+                    CheckboxElement(label="A checkbox inside a group", name="grouped_checkbox")
+                ]),
+                RadioGroupElement(label="A radio group", name="radio", buttons=[
+                    RadioGroupElement.Option(label="Radio Button 1", value="1"),
+                    RadioGroupElement.Option(label="Radio Button 2", value="2")
+                ]),
+                SelectElement(label="A select box", name="select", options=[
+                    SelectElement.Option(label="Option 1", value="1"),
+                    SelectElement.Option(label="Option 2", value="2", selected=True)
+                ]),
+                HiddenElement(name="hidden", value="ill be sent along with the form")
+            ],
+            sections=[FormSection(header="Custom Section", elements=[
+                TextInputElement(label="I'm inside a section!", name="text_input_in_section")
+            ])]
+        )

--- a/questionpy/__init__.py
+++ b/questionpy/__init__.py
@@ -1,2 +1,2 @@
 from questionpy._manifest import Manifest, PackageType  # noqa
-from questionpy._qtype import MissingOptionError, QuestionType  # noqa
+from questionpy._qtype import QuestionType  # noqa

--- a/questionpy/_qtype.py
+++ b/questionpy/_qtype.py
@@ -1,14 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional, Type
 
 from questionpy._manifest import Manifest
 from questionpy.form import Form
-
-
-class MissingOptionError(Exception):
-    def __init__(self, name: str):
-        super().__init__(f"Question option '{name}' was required but not provided")
-        self.name = name
 
 
 class QuestionType(ABC):
@@ -21,8 +15,8 @@ class QuestionType(ABC):
         QuestionType.implementation = cls
 
     @abstractmethod
-    def render_edit_form(self, form: Form) -> None:
+    def render_edit_form(self) -> Form:
         pass
 
-    def validate_options(self, options: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_options(self, options: Any) -> Any:
         return options

--- a/questionpy/form.py
+++ b/questionpy/form.py
@@ -1,12 +1,22 @@
-from typing import Annotated, List, Literal, Union
+from abc import ABC, abstractmethod
+from typing import Annotated, List, Literal, Union, Any, Tuple, Optional, Set
 
 from pydantic import BaseModel, Field
 
 
 class _BaseElement(BaseModel):
     kind: str
-    name: str
     label: str
+
+
+class Submittable(BaseModel, ABC):
+    name: str
+
+    @abstractmethod
+    def to_model_field(self) -> Tuple[Any, Any]:
+        """
+        Returns the (type, default value) tuple as used by :meth:`create_model` for this form element.
+        """
 
 
 class TextElement(_BaseElement):
@@ -14,16 +24,24 @@ class TextElement(_BaseElement):
     text: str
 
 
-class TextInputElement(_BaseElement):
+class TextInputElement(_BaseElement, Submittable):
     kind: Literal["input"] = "input"
+    required: bool = False
+
+    def to_model_field(self) -> Tuple[Any, Any]:
+        return (str, ...) if self.required else (Optional[str], None)
 
 
 class ButtonElement(_BaseElement):
     kind: Literal["button"] = "button"
 
 
-class CheckboxElement(_BaseElement):
+class CheckboxElement(_BaseElement, Submittable):
     kind: Literal["checkbox"] = "checkbox"
+    required: bool = False
+
+    def to_model_field(self) -> Tuple[Any, Any]:
+        return (Literal[True], ...) if self.required else (bool, False)
 
 
 class CheckboxGroupElement(BaseModel):
@@ -31,16 +49,23 @@ class CheckboxGroupElement(BaseModel):
     checkboxes: List[CheckboxElement]
 
 
-class RadioGroupElement(_BaseElement):
+class RadioGroupElement(_BaseElement, Submittable):
     class Option(BaseModel):
         label: str
         value: str
 
     kind: Literal["radio_group"] = "radio_group"
     buttons: List[Option]
+    required: bool = False
+
+    def to_model_field(self) -> Tuple[Any, Any]:
+        option_types = tuple(Literal[option.value] for option in self.buttons)
+        if self.required:
+            return Union[option_types], ...
+        return Optional[Union[option_types]], None
 
 
-class SelectElement(_BaseElement):
+class SelectElement(_BaseElement, Submittable):
     class Option(BaseModel):
         label: str
         value: str
@@ -49,12 +74,26 @@ class SelectElement(_BaseElement):
     kind: Literal["select"] = "select"
     multiple: bool = False
     options: List[Option]
+    required: bool = False
+
+    def to_model_field(self) -> Tuple[Any, Any]:
+        option_types = tuple(Literal[option.value] for option in self.options)
+        if self.multiple:
+            if self.required:
+                return Set[Union[option_types]], ...  # type: ignore[valid-type]
+            return Set[Union[option_types]], None  # type: ignore[valid-type]
+
+        if self.required:
+            return Union[option_types], ...
+        return Optional[Union[option_types]], None
 
 
-class HiddenElement(BaseModel):
+class HiddenElement(Submittable):
     kind: Literal["hidden"] = "hidden"
-    name: str
     value: str
+
+    def to_model_field(self) -> Tuple[Any, Any]:
+        return Literal[self.value], ...
 
 
 FormElement = Annotated[

--- a/questionpy_sdk/__main__.py
+++ b/questionpy_sdk/__main__.py
@@ -1,17 +1,22 @@
+import logging
+import sys
+
 import click
 
 from questionpy_sdk.commands.package import package
 from questionpy_sdk.commands.run import run
-from questionpy_sdk.logging import init_logging
 
 
 @click.group()
-def cli() -> None:
-    init_logging()
+@click.option("-v", "--verbose", is_flag=True, show_default=True, default=False, help="Use log level DEBUG.")
+def cli(verbose: bool) -> None:
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, stream=sys.stderr)
 
 
 cli.add_command(package)
 cli.add_command(run)
 
 if __name__ == '__main__':
+    # PyLint doesn't understand that click.group doesn't return a function
+    # pylint: disable=no-value-for-parameter
     cli()

--- a/questionpy_sdk/commands/run.py
+++ b/questionpy_sdk/commands/run.py
@@ -8,6 +8,7 @@ import click
 
 from questionpy import Manifest, QuestionType
 from questionpy_sdk.runtime import run_qtype
+from questionpy_sdk.server import QPyPackageServer
 
 log = logging.getLogger(__name__)
 
@@ -29,4 +30,5 @@ def run(package: Path, pretty: bool) -> None:
         log.fatal("The package '%s' does not contain an implementation of QuestionType", package)
         sys.exit(1)
 
-    run_qtype(manifest, QuestionType.implementation, pretty=pretty)
+    server = QPyPackageServer(sys.stdin, sys.stdout, pretty=pretty)
+    run_qtype(manifest, QuestionType.implementation, server)

--- a/questionpy_sdk/commands/run.py
+++ b/questionpy_sdk/commands/run.py
@@ -2,11 +2,11 @@ import logging
 import sys
 from importlib import import_module
 from pathlib import Path
-from zipfile import ZipFile
 
 import click
 
-from questionpy import Manifest, QuestionType
+from questionpy import QuestionType
+from questionpy_sdk.package import QPyPackage
 from questionpy_sdk.runtime import run_qtype
 from questionpy_sdk.server import QPyPackageServer
 
@@ -17,18 +17,20 @@ log = logging.getLogger(__name__)
 @click.argument("package", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("-p", "--pretty", is_flag=True, show_default=True, default=False, help="Output indented JSON.")
 def run(package: Path, pretty: bool) -> None:
-    with ZipFile(package) as package_file:
-        manifest = Manifest.parse_raw(package_file.read("qpy_manifest.yml"))
+    with QPyPackage(package, "r") as package_file:
+        old_path = sys.path
+        sys.path = [str(package / "python"), str(package / "dependencies/site-packages"), *sys.path]
 
-    sys.path.insert(0, str(package))
-    try:
-        import_module(manifest.entrypoint)
-    finally:
-        sys.path.remove(str(package))
+        log.debug("Modified sys.path is '%s'", sys.path)
+        try:
+            import_module(package_file.manifest.entrypoint)
 
-    if QuestionType.implementation is None:
-        log.fatal("The package '%s' does not contain an implementation of QuestionType", package)
-        sys.exit(1)
+            if QuestionType.implementation is None:
+                log.fatal("The package '%s' does not contain an implementation of QuestionType", package)
+                sys.exit(1)
 
-    server = QPyPackageServer(sys.stdin, sys.stdout, pretty=pretty)
-    run_qtype(manifest, QuestionType.implementation, server)
+            server = QPyPackageServer(sys.stdin, sys.stdout, pretty=pretty)
+            run_qtype(package_file.manifest, QuestionType.implementation, server)
+        finally:
+            sys.path = old_path
+            log.debug("Reset sys.path to '%s'", sys.path)

--- a/questionpy_sdk/logging.py
+++ b/questionpy_sdk/logging.py
@@ -1,6 +1,0 @@
-import logging
-import sys
-
-
-def init_logging() -> None:
-    logging.basicConfig(level=logging.INFO, stream=sys.stderr)

--- a/questionpy_sdk/messages.py
+++ b/questionpy_sdk/messages.py
@@ -21,20 +21,20 @@ class RenderEditForm(BaseModel):
         form: Form
 
 
-class ValidateOptionsMessage(BaseModel):
-    kind: Literal["validate_options"] = "validate_options"
-    options: Dict[str, Any]
+class CreateQuestionMessage(BaseModel):
+    kind: Literal["create_question"] = "create_question"
+    form_data: Dict[str, Any]
 
     class Response(BaseModel):
         kind: Literal["question_state"] = "question_state"
-        state: Dict[str, Any]
+        state: BaseModel
 
 
 Message = Annotated[
     Union[
         PingMessage, PongMessage,
         RenderEditForm, RenderEditForm.Response,
-        ValidateOptionsMessage, ValidateOptionsMessage.Response
+        CreateQuestionMessage, CreateQuestionMessage.Response
     ],
     Field(discriminator="kind")
 ]

--- a/questionpy_sdk/package.py
+++ b/questionpy_sdk/package.py
@@ -1,0 +1,28 @@
+import logging
+from functools import cached_property
+from pathlib import Path
+from typing import Literal
+from zipfile import ZipFile
+
+from questionpy import Manifest
+
+log = logging.getLogger(__name__)
+
+
+class QPyPackage(ZipFile):
+    def __init__(self, path: Path, mode: Literal["r", "w"]):
+        super().__init__(path, mode)
+
+    def write_manifest(self, manifest: Manifest) -> None:
+        log.info("qpy_manifest.yml: %s", manifest)
+        self.writestr("qpy_manifest.yml", manifest.yaml())
+
+    def write_glob(self, prefix: str, source_dir: Path, glob: str) -> None:
+        for source_file in source_dir.glob(glob):
+            path_in_pkg = prefix / source_file.relative_to(source_dir)
+            log.info("%s: %s", path_in_pkg, source_file)
+            self.write(source_file, path_in_pkg)
+
+    @cached_property
+    def manifest(self) -> Manifest:
+        return Manifest.parse_raw(self.read("qpy_manifest.yml"))

--- a/questionpy_sdk/runtime.py
+++ b/questionpy_sdk/runtime.py
@@ -1,30 +1,55 @@
 import logging
-import sys
-from typing import Type
+from itertools import chain
+from typing import Type, Any, Dict, Union
+
+from pydantic import BaseModel, create_model
 
 from questionpy import Manifest, QuestionType
-from questionpy.form import Form
-from questionpy_sdk.messages import PingMessage, PongMessage, RenderEditForm, ValidateOptionsMessage
+from questionpy.form import Form, CheckboxElement, HiddenElement, RadioGroupElement, SelectElement, \
+    TextInputElement, Submittable
+from questionpy_sdk.messages import PingMessage, PongMessage, RenderEditForm, CreateQuestionMessage
 from questionpy_sdk.server import QPyPackageServer
 
 log = logging.getLogger(__name__)
 
+RelevantFormElement = Union[TextInputElement, CheckboxElement, HiddenElement, RadioGroupElement, SelectElement]
+"""
+Union of the form elements which produce options on submission.
+"""
 
-def run_qtype(manifest: Manifest, qtype: Type[QuestionType], *, pretty: bool = False) -> None:
+
+def _form_to_model(form: Form) -> Type[BaseModel]:
+    """
+    Generates a pydantic model from the given form describing the expected options when the form is submitted.
+    The model can be used for validation of submitted form data.
+    """
+    all_elements = [*form.general, *chain.from_iterable(section.elements for section in form.sections)]
+    fields: Dict[str, Any] = {element.name: element.to_model_field() for element in all_elements if
+                              isinstance(element, Submittable)}
+    return create_model("Options", **fields)
+
+
+def _parse_options(qtype: QuestionType, options: Dict[str, Any]) -> BaseModel:
+    # FIXME: We use a new form here, but a question type may choose to generate a new form on each invocation, so we
+    #        should get the one which was submitted instead.
+    form = qtype.render_edit_form()
+    model = _form_to_model(form)
+    return model.parse_obj(options)
+
+
+def run_qtype(manifest: Manifest, qtype: Type[QuestionType], server: QPyPackageServer) -> None:
     qtype_instance = qtype(manifest=manifest)
 
     log.info("Running question type '%s:%s' with manifest '%s'",
              qtype.__module__, qtype.__name__, manifest)
 
-    server = QPyPackageServer(sys.stdin, sys.stdout, pretty=pretty)
     for message in server:
         if isinstance(message, PingMessage):
             server.send(PongMessage())
         elif isinstance(message, RenderEditForm):
-            form = Form()
-            qtype_instance.render_edit_form(form)
-            server.send(RenderEditForm.Response(form=form))
-        elif isinstance(message, ValidateOptionsMessage):
-            server.send(ValidateOptionsMessage.Response(state=qtype_instance.validate_options(message.options)))
+            server.send(RenderEditForm.Response(form=qtype_instance.render_edit_form()))
+        elif isinstance(message, CreateQuestionMessage):
+            parsed_options = _parse_options(qtype_instance, message.form_data)
+            server.send(CreateQuestionMessage.Response(state=qtype_instance.validate_options(parsed_options)))
         else:
             log.error("Unsupported message type: %s", type(message).__name__)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,160 @@
+from io import StringIO
+from typing import List
+
+import pytest
+from pydantic import ValidationError
+
+from questionpy import Manifest, QuestionType
+from questionpy.form import Form, TextInputElement, RadioGroupElement, SelectElement
+from questionpy_sdk.messages import Message, CreateQuestionMessage, RenderEditForm, PingMessage, PongMessage
+from questionpy_sdk.runtime import run_qtype
+from questionpy_sdk.server import QPyPackageServer
+
+
+class MockServer(QPyPackageServer):
+    def __init__(self, queue: List[Message]):
+        super().__init__(StringIO(), StringIO())
+        self.queue: List[Message] = queue
+        self.sent: List[Message] = []
+
+    def __next__(self) -> Message:
+        try:
+            return self.queue.pop()
+        except IndexError as e:
+            raise StopIteration from e
+
+    def send(self, message: Message) -> None:
+        self.sent.append(message)
+
+
+A_MANIFEST = Manifest(short_name="test", version="0.1.0", api_version="0.1", author="Alice Sample <alice@example.org>")
+
+
+class NoopQType(QuestionType):
+    def render_edit_form(self) -> Form:
+        return Form()
+
+
+def test_ping() -> None:
+    server = MockServer([PingMessage()])
+
+    run_qtype(A_MANIFEST, NoopQType, server)
+
+    assert server.sent == [PongMessage()]
+
+
+def test_render_edit_form() -> None:
+    server = MockServer([RenderEditForm()])
+
+    form = Form(general=[
+        TextInputElement(name="required", label="", required=True),
+        TextInputElement(name="optional", label="")
+    ])
+
+    class QType(QuestionType):
+        def render_edit_form(self) -> Form:
+            return form
+
+    run_qtype(A_MANIFEST, QType, server)
+
+    assert server.sent == [RenderEditForm.Response(form=form)]
+
+
+def test_valid_options() -> None:
+    options = {
+        "required": "123",
+        "radio_group": "selected_value"
+    }
+
+    server = MockServer([CreateQuestionMessage(form_data=options)])
+
+    class QType(QuestionType):
+        def render_edit_form(self) -> Form:
+            return Form(general=[
+                TextInputElement(name="required", label="", required=True),
+                TextInputElement(name="optional", label=""),
+                RadioGroupElement(
+                    name="radio_group",
+                    label="",
+                    buttons=[RadioGroupElement.Option(label="", value="selected_value")]
+                )
+            ])
+
+    run_qtype(A_MANIFEST, QType, server)
+
+    assert len(server.sent) == 1
+    assert isinstance(server.sent[0], CreateQuestionMessage.Response)
+    assert server.sent[0].state.dict() == {
+        "required": "123",
+        "optional": None,
+        "radio_group": "selected_value"
+    }
+
+
+def test_missing_option() -> None:
+    options = {
+        "optional": "123"
+    }
+
+    class QType(QuestionType):
+        def render_edit_form(self) -> Form:
+            return Form(general=[
+                TextInputElement(name="required", label="", required=True),
+                TextInputElement(name="optional", label="")
+            ])
+
+    server = MockServer([CreateQuestionMessage(form_data=options)])
+
+    with pytest.raises(ValidationError):
+        run_qtype(A_MANIFEST, QType, server)
+
+    assert not server.sent
+
+
+def test_select_wrong_value() -> None:
+    options = {
+        "select": "anothervalue"
+    }
+
+    class QType(QuestionType):
+        def render_edit_form(self) -> Form:
+            return Form(general=[
+                SelectElement(name="select", label="", options=[SelectElement.Option(label="", value="value1"),
+                                                                SelectElement.Option(label="", value="value2")])
+            ])
+
+    server = MockServer([CreateQuestionMessage(form_data=options)])
+
+    with pytest.raises(ValidationError):
+        run_qtype(A_MANIFEST, QType, server)
+
+    assert not server.sent
+
+
+def test_select_multiple_wrong_value() -> None:
+    options = {
+        "select": {"value1", "anothervalue"}
+    }
+
+    class QType(QuestionType):
+        def render_edit_form(self) -> Form:
+            return Form(general=[
+                SelectElement(name="select", label="", multiple=True,
+                              options=[SelectElement.Option(label="", value="value1"),
+                                       SelectElement.Option(label="", value="value2")])
+            ])
+
+    server = MockServer([CreateQuestionMessage(form_data=options)])
+
+    with pytest.raises(ValidationError):
+        run_qtype(A_MANIFEST, QType, server)
+
+    assert not server.sent
+
+
+def test_unsupported_message_type(caplog: pytest.LogCaptureFixture) -> None:
+    server = MockServer([object()])  # type: ignore[list-item]
+
+    run_qtype(A_MANIFEST, NoopQType, server)
+
+    assert any("Unsupported message type: object" in record.message for record in caplog.records)


### PR DESCRIPTION
Aus der Form, die der Fragetyp generiert, wird ein [pydantic-Model generiert](https://pydantic-docs.helpmanual.io/usage/models/#dynamic-model-creation), mit dem dann die options geparsed werden. Dadurch werden auch die Typen validiert, und der Fragetyp kriegt dann ein Objekt statt eines Dicts. Man könnte dem Paket auch mal erlauben, ein eigenes Modell anzugeben.

Momentan wird dafür auch noch die Form neu generiert. Da könnte der Fragetyp theoretisch auch eine ganz andere erstellen als vom User ausgefüllt wurde. Vermutlich sollten wir die verwendete Form also wieder mitschicken?

Closes #5