### PR TITLE
pytest-cov entfernen, Coverage.py separat ausführen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   ci:
     # https://github.com/questionpy-org/.github
-    uses: questionpy-org/.github/.github/workflows/python-ci.yml@v2
+    uses: questionpy-org/.github/.github/workflows/python-ci.yml@v3
     with:
       packages: questionpy questionpy_sdk

--- a/coverage.sh
+++ b/coverage.sh
@@ -7,7 +7,8 @@ printf -- 'running pylint \n'
 pylint questionpy questionpy_sdk tests
 
 printf -- 'running pytest \n'
-pytest tests
+coverage run -m pytest tests
+coverage report
 
 printf -- 'running mypy \n'
 mypy questionpy questionpy_sdk tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -124,7 +124,7 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.2"
+version = "1.0.4"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -135,7 +135,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "faker"
-version = "15.3.1"
+version = "15.3.2"
 description = "Faker is a Python package that generates fake data for you."
 category = "main"
 optional = false
@@ -421,21 +421,6 @@ pytest = ">=6.1.0"
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
-name = "pytest-cov"
-version = "3.0.0"
-description = "Pytest plugin for measuring coverage."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
-pytest = ">=4.6"
-
-[package.extras]
-testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
-
-[[package]]
 name = "pytest-md"
 version = "0.2.0"
 description = "Plugin for generating Markdown reports for pytest results"
@@ -501,8 +486,8 @@ questionpy-common = {git = "https://github.com/questionpy-org/questionpy-common.
 [package.source]
 type = "git"
 url = "https://github.com/questionpy-org/questionpy-server.git"
-reference = "19c588a"
-resolved_reference = "19c588a6ed6c198749cb6b9a3fddcfdc43b0ab16"
+reference = "f6db4fa"
+resolved_reference = "f6db4fa1c03a49de8ee5392f6365e6481e2acf97"
 
 [[package]]
 name = "six"
@@ -567,7 +552,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "1700687f7fd64c818bbfc95cb5bf25751fe2dca3ddeafb456328b48e21f0e0f8"
+content-hash = "60ea01a17bbde2a3ddb5b366f8c5d5a57b93ee2eba1aaa8028eb83622437180b"
 
 [metadata.files]
 aiohttp = [
@@ -744,12 +729,12 @@ dill = [
     {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.2-py3-none-any.whl", hash = "sha256:c22f11ec6a10d2b453871c5c5fe887436c4d1961324ce9090f2ca6ddc4180c27"},
-    {file = "exceptiongroup-1.0.2.tar.gz", hash = "sha256:a31cd183c3dea02e617aab5153588d5f7258a77b51f0ef41b3815ae8a0d0f695"},
+    {file = "exceptiongroup-1.0.4-py3-none-any.whl", hash = "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828"},
+    {file = "exceptiongroup-1.0.4.tar.gz", hash = "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"},
 ]
 faker = [
-    {file = "Faker-15.3.1-py3-none-any.whl", hash = "sha256:4a3465624515a6807e8aa7e8eeb85bdd86a2fa53de4e258892dd6be95362462e"},
-    {file = "Faker-15.3.1.tar.gz", hash = "sha256:b9dd2fd9a9ac68a4e0c5040cd9e9bfaa099fa8dd15bae5f01f224a45431818d5"},
+    {file = "Faker-15.3.2-py3-none-any.whl", hash = "sha256:43da04aae745018e8bded768e74c84423d9dc38e4c498a53439e749d90e20bc0"},
+    {file = "Faker-15.3.2.tar.gz", hash = "sha256:0094fe3340ad73c490d3ffccc59cc171b161acfccccd52925c70970ba23e6d6b"},
 ]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
@@ -1042,10 +1027,6 @@ pytest-aiohttp = [
 pytest-asyncio = [
     {file = "pytest-asyncio-0.20.2.tar.gz", hash = "sha256:32a87a9836298a881c0ec637ebcc952cfe23a56436bdc0d09d1511941dd8a812"},
     {file = "pytest_asyncio-0.20.2-py3-none-any.whl", hash = "sha256:07e0abf9e6e6b95894a39f688a4a875d63c2128f76c02d03d16ccbc35bcc0f8a"},
-]
-pytest-cov = [
-    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
-    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
 pytest-md = [
     {file = "pytest-md-0.2.0.tar.gz", hash = "sha256:3b248d5b360ea5198e05b4f49c7442234812809a63137ec6cdd3643a40cf0112"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,19 +15,19 @@ python = "^3.9"
 aiohttp = "^3.8.1"
 pydantic = "^1.9.1"
 PyYAML = "^6.0"
-questionpy-common = {git = "https://github.com/questionpy-org/questionpy-common.git", rev = "a217e38"}
-questionpy-server = {git = "https://github.com/questionpy-org/questionpy-server.git", rev = "f6db4fa"}
+questionpy-common = { git = "https://github.com/questionpy-org/questionpy-common.git", rev = "a217e38" }
+questionpy-server = { git = "https://github.com/questionpy-org/questionpy-server.git", rev = "f6db4fa" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.14.5"
 pytest = "^7.1.2"
 pytest-aiohttp = "^1.0.4"
 pytest-md = "^0.2.0"
-pytest-cov = "^3.0.0"
 pylint-pytest = "^1.1.2"
 mypy = "^0.971"
 flake8 = "^5.0.4"
 types-PyYAML = "^6.0.11"
+coverage = { extras = ["toml"], version = "^6.5.0" }
 
 [tool.poetry.scripts]
 questionpy-sdk = 'questionpy_sdk.__main__:cli'
@@ -35,9 +35,10 @@ questionpy-sdk = 'questionpy_sdk.__main__:cli'
 [tool.pytest.ini_options]
 # https://github.com/pytest-dev/pytest-asyncio#auto-mode
 asyncio_mode = "auto"
-addopts = "--cov --cov-config=pyproject.toml --cov-branch --cov-report term:skip-covered"
 
 
+# This section is read automatically by Coverage.py when its working directory is .
+# https://coverage.readthedocs.io/en/6.5.0/config.html#configuration-reference
 [tool.coverage.run]
 branch = true
 source = ["questionpy", "questionpy_sdk"]


### PR DESCRIPTION
Vorher hat das Pytest-Plugin `pytest-cov` innerhalb des `pytest`-Befehls Coverage.py ausgeführt. Das hatte zwei Nachteile:
* Wird pytest in `tests` als working directory ausgeführt (was IntelliJ macht, wenn man einen einzelnen Test im UI ausführt), dann wird die in `--cov-config=pyproject.toml` nicht gefunden, was zu einem Fehler führt
* Wird in IntelliJ "Run with Coverage gewählt", führt es von sich aus Coverage.py um pytest herum aus. Mit pytest-cov läuft Coverage.py deshalb doppelt, was Dinge kaputt macht

Stattdessen führen wir in `coverage.sh` und der CI jetzt genau wie IntelliJ erst Coverage.py, dann darin pytest aus. Wird Coverage.py im Projektordner als Working Directory ausgeführt, lädt es automatisch die pyproject.toml. Ansonsten nicht, was aber keinen Fehler darstellt.