### PR TITLE
QuestionType implementiert BaseQuestionType

### DIFF
--- a/example/qpy_manifest.yml
+++ b/example/qpy_manifest.yml
@@ -1,5 +1,9 @@
 short_name: example
 version: 0.1.0
 api_version: 0.1
-entrypoint: main
 author: Maximilian Haye <m.haye@tu-berlin.de>
+name:
+  de: Beispiel
+  en: Example
+entrypoint: main
+languages: [de, en]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ description = "Library and toolset for the development of QuestionPy packages"
 authors = ["innoCampus <info@isis.tu-berlin.de>"]
 homepage = "https://questionpy.org"
 version = "0.2.0"
+packages = [
+    { include = "questionpy" },
+    { include = "questionpy_sdk" }
+]
 
 [tool.poetry.dependencies]
 click = "^8.1.3"

--- a/questionpy/_qtype.py
+++ b/questionpy/_qtype.py
@@ -1,14 +1,13 @@
-from abc import ABC
 from typing import Any, Optional, Type, Generic, TypeVar, ClassVar, get_args, get_origin, cast
 
-from questionpy_common.qtype import OptionsFormDefinition
+from questionpy_common.qtype import OptionsFormDefinition, BaseQuestionType, BaseQuestion
 
 from questionpy.form import FormModel
 
 F = TypeVar("F", bound=FormModel)
 
 
-class QuestionType(ABC, Generic[F]):
+class QuestionType(BaseQuestionType, Generic[F]):
     form_model: ClassVar[Type[FormModel]]
     implementation: ClassVar[Optional[Type["QuestionType"]]] = None
 
@@ -43,3 +42,9 @@ class QuestionType(ABC, Generic[F]):
 
     def validate_options(self, options: Any) -> F:
         return cast(F, self.form_model.parse_obj(options))
+
+    def create_question_from_options(self, form_data: dict) -> BaseQuestion:
+        raise NotImplementedError()
+
+    def create_question_from_state(self, question_state: str) -> BaseQuestion:
+        raise NotImplementedError()

--- a/questionpy_sdk/commands/package.py
+++ b/questionpy_sdk/commands/package.py
@@ -16,8 +16,10 @@ log = logging.getLogger(__name__)
 @click.command()
 @click.argument("source", type=click.Path(exists=True, file_okay=False, path_type=Path))
 @click.option("--manifest", "-m", "manifest_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
-def package(source: Path, manifest_path: Optional[Path]) -> None:
-    out_path = source.with_suffix(".qpy")
+@click.option("--out", "-o", "out_path", type=click.Path(exists=False, dir_okay=False, path_type=Path))
+def package(source: Path, manifest_path: Optional[Path], out_path: Optional[Path]) -> None:
+    if not out_path:
+        out_path = source.with_suffix(".qpy")
 
     if not manifest_path:
         manifest_path = source / "qpy_manifest.yml"

--- a/questionpy_sdk/commands/run.py
+++ b/questionpy_sdk/commands/run.py
@@ -3,7 +3,6 @@ import logging
 from pathlib import Path
 
 import click
-
 from questionpy_server import WorkerPool
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
QuestionType fehlte der Konstruktor, der das Manifest nimmt, deshalb habe ich jetzt wieder BaseQuestionType als Überklasse hinzugefügt (wie es ja auch gedacht war)

create_question_from_options und create_question_from_state und wo validate_options da rein passt müssen wir dann nochmal separat beratschlagen.