### PR TITLE
feat: use `{namespace}-{short_name}-{version}.qpy` as default path

### DIFF
--- a/questionpy_sdk/commands/package.py
+++ b/questionpy_sdk/commands/package.py
@@ -39,7 +39,7 @@ def package(source: Path, manifest_path: Optional[Path], out_path: Optional[Path
     if not out_path:
         out_path = Path(f"{manifest.namespace}-{manifest.short_name}-{manifest.version}.qpy")
     if out_path.exists():
-        if not click.confirm(f"The path '{out_path}' already exists. Do you want to override it?"):
+        if not click.confirm(f"The path '{out_path}' already exists. Do you want to overwrite it?"):
             click.echo("Aborting.")
             return
         out_path.unlink()

--- a/questionpy_sdk/commands/package.py
+++ b/questionpy_sdk/commands/package.py
@@ -27,13 +27,6 @@ def validate_out_path(context: click.Context, _parameter: click.Parameter, value
 @click.option("--manifest", "-m", "manifest_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("--out", "-o", "out_path", callback=validate_out_path, type=click.Path(path_type=Path))
 def package(source: Path, manifest_path: Optional[Path], out_path: Optional[Path]) -> None:
-    if not out_path:
-        out_path = source.with_suffix(".qpy")
-    if out_path.exists():
-        if not click.confirm(f"The path '{out_path}' already exists. Do you want to override it?"):
-            return
-        out_path.unlink()
-
     if not manifest_path:
         manifest_path = source / "qpy_manifest.yml"
 
@@ -43,11 +36,21 @@ def package(source: Path, manifest_path: Optional[Path], out_path: Optional[Path
     with manifest_path.open() as manifest_f:
         manifest = Manifest.parse_obj(yaml.safe_load(manifest_f))
 
+    if not out_path:
+        out_path = Path(f"{manifest.namespace}-{manifest.short_name}-{manifest.version}.qpy")
+    if out_path.exists():
+        if not click.confirm(f"The path '{out_path}' already exists. Do you want to override it?"):
+            click.echo("Aborting.")
+            return
+        out_path.unlink()
+
     with PackageBuilder(out_path) as out_file:
         _copy_package(out_file, questionpy)
         _install_dependencies(out_file, manifest_path, manifest)
         out_file.write_glob(source, "python/**/*")
         out_file.write_manifest(manifest)
+
+    click.echo(f"Successfully created '{out_path}'.")
 
 
 def _install_dependencies(target: PackageBuilder, manifest_path: Path, manifest: Manifest) -> None:


### PR DESCRIPTION
Beim Paketieren wird als Default-Ausgabepfad nicht mehr `{source}.qpy`, sondern `{namespace}-{short_name}-{version}.qpy` verwendet, da dieser Name deutlich aussagekräftiger ist. ([Debian-Pakete werden ähnlich benannt.](https://manpages.debian.org/bullseye/dpkg-dev/dpkg-name.1.en.html):  `{package}_{version}_{architecture}.deb`.)