### PR TITLE
Dokumentation mit mkdocs

### DIFF
--- a/docs/reference/questionpy.md
+++ b/docs/reference/questionpy.md
@@ -1,0 +1,20 @@
+
+::: questionpy._qtype
+    options:
+        show_if_no_docstring: true
+        heading_level: 3
+        show_root_full_path: false
+        filters: ["!F"]
+
+::: questionpy.form._dsl
+    options:
+        show_if_no_docstring: true
+        heading_level: 3
+        show_root_full_path: false
+        filters: ["!_"]
+
+::: questionpy.form._model
+    options:
+        show_if_no_docstring: true
+        heading_level: 3
+        show_root_full_path: false

--- a/docs/reference/questionpy_sdk.md
+++ b/docs/reference/questionpy_sdk.md
@@ -1,0 +1,22 @@
+
+# QuestionPy SDK
+
+## Commands
+
+::: questionpy_sdk.commands.create.create
+    options:
+        show_if_no_docstring: true
+        heading_level: 3
+        show_root_full_path: false
+
+::: questionpy_sdk.commands.package.package
+    options:
+        show_if_no_docstring: true
+        heading_level: 3
+        show_root_full_path: false
+
+::: questionpy_sdk.commands.run.run
+    options:
+        show_if_no_docstring: true
+        heading_level: 3
+        show_root_full_path: false

--- a/questionpy/form/_model.py
+++ b/questionpy/form/_model.py
@@ -45,8 +45,7 @@ class OptionEnum(Enum):
 @dataclass
 class _FieldInfo:
     build: Callable[[str], FormElement]
-    """
-    We want to use the name of the model field as the name of the form element, but that isn't known when the dsl
+    """We want to use the name of the model field as the name of the form element, but that isn't known when the dsl
     functions are called. So they provide a callable instead which takes the name and returns the complete form element.
     """
     type: object
@@ -79,9 +78,7 @@ def _flatten_elements(elements: Iterable[FormElement], sections: Iterable[FormSe
 
 
 def _is_valid_annotation(annotation: object, expected: object) -> bool:
-    """
-    Checks if `annotation` is valid for a form element which produces values of type `expected`.
-    """
+    """Checks if `annotation` is valid for a form element which produces values of type `expected`."""
 
     # TODO: pydantic is able to coerce many input values, such as strings to floats, so better logic may be
     #       needed here

--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -32,7 +32,7 @@ class WebServer:
 
 @routes.get('/')
 async def render_options(_request: web.Request) -> web.Response:
-    """  Get the options form definition that allow a question creator to customize a question. """
+    """Get the options form definition that allow a question creator to customize a question."""
     webserver: 'WebServer' = _request.app['sdk_webserver_app']
 
     async with webserver.worker_pool.get_worker(webserver.package, 0, None) as worker:


### PR DESCRIPTION
Analog zu [PR 49](https://github.com/questionpy-org/questionpy-server/pull/49).

Dieser PR beinhaltet: 
- die Umstellung der bestehenden docstrings auf den Google Docstring Stil
- die neuen .md files, die von [questionpy-docs](https://github.com/questionpy-org/questionpy-docs) benötigt werden.