### PR TITLE
Referenzen über Sektionen und Gruppen hinweg

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ version: 0.1.0
 api_version: 0.1
 # You or your organization
 author: Bob Sample <bob@example.org>
-# Optional: The module within your package which should be imported when the package is run
+# Optional: The module within your package that should be imported when the package is run
 entrypoint: main
 ```
 

--- a/questionpy/_qtype.py
+++ b/questionpy/_qtype.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ValidationError
 from questionpy_common.qtype import OptionsFormDefinition, BaseQuestionType, BaseQuestion, OptionsFormValidationError
 
 from questionpy.form import FormModel
+from questionpy.form.validation import validate_form
 
 F = TypeVar("F", bound=FormModel)
 
@@ -34,6 +35,7 @@ class QuestionType(BaseQuestionType, Generic[F]):
                     if not isinstance(args[0], type) or not issubclass(args[0], FormModel):
                         raise TypeError(f"Type parameter '{args[0]!r}' of QuestionType is not a subclass of FormModel")
                     cls.form_model = args[0]
+                    validate_form(cls.form_model.qpy_form)
                 else:
                     # QuestionType was used without parameters, default to an empty form model
                     cls.form_model = FormModel
@@ -46,7 +48,7 @@ class QuestionType(BaseQuestionType, Generic[F]):
     def get_options_form(self, question_state: Optional[dict[str, object]]) \
             -> tuple[OptionsFormDefinition, dict[str, object]]:
         return (
-            self.form_model.form(),
+            self.form_model.qpy_form,
             question_state or {}
         )
 

--- a/questionpy/form/_dsl.py
+++ b/questionpy/form/_dsl.py
@@ -432,7 +432,7 @@ def group(label: str, model: Type[_F], *,
     """
     # We pretend to return an instance of the model so the type of the section field can be inferred.
     return cast(_F, _FieldInfo(
-        lambda name: GroupElement(name=name, label=label, elements=list(model.form_elements()),
+        lambda name: GroupElement(name=name, label=label, elements=model.qpy_form.general,
                                   disable_if=_listify(disable_if), hide_if=_listify(hide_if)),
         model
     ))
@@ -466,7 +466,7 @@ def repeat(model: Type[_F], *, initial: int = 1, increment: int = 1, button_labe
     """
     return cast(list[_F], _FieldInfo(
         lambda name: RepetitionElement(name=name, initial_elements=initial, increment=increment,
-                                       button_label=button_label, elements=list(model.form_elements())),
+                                       button_label=button_label, elements=model.qpy_form.general),
         list[model]  # type: ignore[valid-type]
     ))
 

--- a/questionpy/form/_dsl.py
+++ b/questionpy/form/_dsl.py
@@ -21,7 +21,7 @@ References:
     - An element name, or
     - ``..``, which resolves to the parent element
 
-    A reference is always relative to the element which defines it. For example, the condition
+    A reference is always relative to the element that defines it. For example, the condition
     ``is_checked(..[foo][bar])`` is resolved as follows:
 
     - Get the parent of the model in which the reference is made. If the reference is made at the top level, it is
@@ -375,7 +375,7 @@ def hidden(value: _S, *, disable_if: _ZeroOrMoreConditions = None, hide_if: _Zer
 
 
 def section(header: str, model: Type[_F]) -> _F:
-    """Adds a form section which can be expanded and collapsed.
+    """Adds a form section that can be expanded and collapsed.
 
     Args:
         header: Header to be shown at the top of the section.
@@ -418,7 +418,7 @@ def group(label: str, model: Type[_F], *,
 
     Examples:
         This example shows a text input field directly followed by a drop-down with possible units. We define a separate
-        ``FormModel`` subclass which will contain our grouped inputs.
+        ``FormModel`` subclass that will contain our grouped inputs.
 
         >>> class SizeGroup(FormModel):
         ...     amount = text_input("Amount")
@@ -445,14 +445,14 @@ def repeat(model: Type[_F], *, initial: int = 1, increment: int = 1, button_labe
         model: Sub-FormModel containing the fields to repeat.
         initial: Number of repetitions to show when the form is first loaded.
         increment: Number of repetitions to add with each click of the button.
-        button_label: Label for the button which adds more repetitions, or None to use default provided by LMS.
+        button_label: Label for the button that adds more repetitions, or None to use default provided by LMS.
 
     Returns:
         An internal object containing metadata about the section.
 
     Examples:
         The following shows part of a simplified multiple-choice question. A separate sub-model defines the elements
-        which should be repeated.
+        that should be repeated.
 
         >>> class Choice(FormModel):
         ...     text = text_input("Choice")

--- a/questionpy/form/_model.py
+++ b/questionpy/form/_model.py
@@ -14,7 +14,7 @@ class _OptionInfo:
     selected: bool
 
 
-class OptionEnum(Enum):
+class OptionEnum(str, Enum):
     """Enum specifying the possible options for radio groups and drop-downs.
 
     Specify options using `option`.

--- a/questionpy/form/_model.py
+++ b/questionpy/form/_model.py
@@ -49,7 +49,7 @@ class OptionEnum(str, Enum):
 class _FieldInfo:
     build: Callable[[str], FormElement]
     """We want to use the name of the model field as the name of the form element, but that isn't known when the dsl
-    functions are called. So they provide a callable instead which takes the name and returns the complete form element.
+    functions are called. So they provide a callable instead that takes the name and returns the complete form element.
     """
     type: object
     """The type of the field."""
@@ -69,7 +69,7 @@ class _SectionInfo:
 
 
 def _is_valid_annotation(annotation: object, expected: object) -> bool:
-    """Checks if `annotation` is valid for a form element which produces values of type `expected`."""
+    """Checks if `annotation` is valid for a form element that produces values of type `expected`."""
 
     # TODO: pydantic is able to coerce many input values, such as strings to floats, so better logic may be
     #       needed here

--- a/questionpy/form/validation.py
+++ b/questionpy/form/validation.py
@@ -18,7 +18,7 @@ class FormError(Exception):
     """A node in the form failed validation."""
     def __init__(self, node: str, message: str):
         self.node = node
-        """Absolute name of the form node which caused the error."""
+        """Absolute name of the form node that caused the error."""
         super().__init__(f"In '{node}': {message}")
 
 
@@ -26,11 +26,11 @@ class FormReferenceError(FormError):
     """A node in the form failed validation because it references a nonexistent element."""
     def __init__(self, node: str, reference: str, container_name: Optional[str], local_name: str):
         self.reference = reference
-        """Full reference which could not be resolved."""
+        """Full reference that could not be resolved."""
         self.container_name = container_name
         """Container of which a direct child was not found."""
         self.local_name = local_name
-        """Local name of the direct child which was not found."""
+        """Local name of the direct child that was not found."""
 
         message = f"Unresolved reference '{reference}'"
         if container_name:
@@ -131,7 +131,7 @@ def validate_form(form: OptionsFormDefinition) -> None:
     resolves to an element, and that that element is a valid target for the condition kind:
 
     - `is_(not_)checked` conditions may only point to :class:`CheckboxElement`\\ s.
-    - `equals`, `does_not_equal` and `is_in` conditions may point to all input elements which produce a value, including
+    - `equals`, `does_not_equal` and `is_in` conditions may point to all input elements that produce a value, including
       :class:`CheckboxElement`.
 
     Args:

--- a/questionpy/form/validation.py
+++ b/questionpy/form/validation.py
@@ -1,0 +1,119 @@
+from itertools import chain
+from typing import Union, Sequence, Optional
+
+from questionpy_common.conditions import IsChecked, IsNotChecked, Equals, DoesNotEqual, In
+from questionpy_common.elements import OptionsFormDefinition, FormSection, GroupElement, RepetitionElement, \
+    FormElement, CanHaveConditions, CheckboxElement, TextInputElement, RadioGroupElement, SelectElement, HiddenElement
+from typing_extensions import TypeAlias
+
+_FormNode: TypeAlias = Union[OptionsFormDefinition, FormSection, FormElement]
+
+
+class FormError(Exception):
+    def __init__(self, node: str, message: str):
+        self.node = node
+        """Absolute name of the form node which caused the error."""
+        super().__init__(f"In '{node}': {message}")
+
+
+class FormReferenceError(FormError):
+    def __init__(self, node: str, reference: str, container_name: Optional[str], local_name: str):
+        self.reference = reference
+        """Full reference which could not be resolved."""
+        self.container_name = container_name
+        """Container of which a direct child was not found."""
+        self.local_name = local_name
+        """Local name of the direct child which was not found."""
+
+        message = f"Unresolved reference '{reference}'"
+        if container_name:
+            message += f" (Element or section '{container_name}' contains no sub-element named '{local_name}')"
+        else:
+            message += f" (Form contains no general element or section named '{local_name}')"
+        super().__init__(node, message)
+
+
+def _absolute_name(node: Union[_FormNode, str], *nodes: Union[_FormNode, str]) -> str:
+    name_parts = []
+    for node in (node, *nodes):
+        if isinstance(node, str):
+            name_parts.append(node)
+        elif not isinstance(node, OptionsFormDefinition):
+            name_parts.append(node.name)
+
+    return name_parts[0] + "".join(f"[{part}]" for part in name_parts[1:])
+
+
+def _resolve_reference(reference: str, referee: str, parents: Sequence[_FormNode]) -> _FormNode:
+    parents = list(parents)
+    parts = reference.replace("]", "").split("[")
+    if not parts:
+        raise FormError(referee, f"Empty reference: '{reference}'")
+
+    for i, part in enumerate(parts):
+        if part == "..":
+            parents.pop()
+            continue
+
+        children = _get_children(parents[-1])
+
+        matching_children = [child for child in children if hasattr(child, "name") and child.name == part]
+        if not matching_children:
+            # Element not found.
+            raise FormReferenceError(referee, reference, getattr(parents[-1], "name", None), part)
+        if len(matching_children) > 1:
+            # Ambiguous reference, i.e. duplicate name.
+            raise FormError(_absolute_name(*parents, part), "Duplicate element or section name")
+        matching_child = matching_children[0]
+
+        if i < len(parts) - 1 and isinstance(matching_child, RepetitionElement):
+            # Since each sub-element of a RepetitionElement may be rendered many times, a reference into it would be
+            # ambiguous.
+            raise FormError(referee, f"Cannot reference repeated element '{reference}' from the outside")
+
+        parents.append(matching_child)
+
+    # Reference points to parents[-1].
+    return parents[-1]
+
+
+def _get_children(node: _FormNode) -> Sequence[_FormNode]:
+    if isinstance(node, OptionsFormDefinition):
+        return *node.general, *node.sections
+
+    if isinstance(node, (FormSection, GroupElement, RepetitionElement)):
+        return node.elements
+
+    # Node is a leaf, i.e. can't have children.
+    return []
+
+
+_valid_referents: dict[type, tuple[type, ...]] = {
+    IsChecked: (CheckboxElement,),
+    IsNotChecked: (CheckboxElement,),
+    Equals: (TextInputElement, CheckboxElement, RadioGroupElement, SelectElement, HiddenElement),
+    DoesNotEqual: (TextInputElement, CheckboxElement, RadioGroupElement, SelectElement, HiddenElement),
+    In: (TextInputElement, CheckboxElement, RadioGroupElement, SelectElement, HiddenElement)
+}
+
+
+def _validate_node(node: _FormNode, parents: Sequence[_FormNode]) -> None:
+    if isinstance(node, CanHaveConditions) and (node.disable_if or node.hide_if):
+        abs_name = _absolute_name(*parents, node)
+
+        for condition in chain(node.disable_if, node.hide_if):
+            target = _resolve_reference(condition.name, abs_name, parents)
+
+            valid_targets = _valid_referents[type(condition)]
+            if not isinstance(target, valid_targets):
+                valid_targets_str = ", ".join(klass.__name__ for klass in valid_targets)
+                raise FormError(abs_name, f"{type(condition).__name__} condition referent is {type(target).__name__} "
+                                          f"but must be one of {valid_targets_str}")
+
+    children = _get_children(node)
+    for child in children:
+        _validate_node(child, (*parents, node))
+
+
+def validate_form(form: OptionsFormDefinition) -> None:
+    _validate_node(form, [])

--- a/questionpy_sdk/webserver/static/script.js
+++ b/questionpy_sdk/webserver/static/script.js
@@ -2,7 +2,7 @@ import * as conditions from "./conditions.js";
 
 
 /**
- * Selects all elements which have a list of conditions as a data attribute. The lists of conditions are an
+ * Selects all elements that have a list of conditions as a data attribute. The lists of conditions are an
  * unparsed JSON string and represent either a hide_if list or a disable_if list (see: {@link conditions.Types}).
  *
  *
@@ -47,7 +47,7 @@ function add_conditions_to_element(element, condition_type){
 /**
  * Adds the source element to the targets list of source elements.
  * Adds the event listener corresponding to the condition_type to the target.
- * When the targets event listener is triggered, the source list contains all the elements which conditions have to be
+ * When the target's event listener is triggered, the source list contains all the elements whose conditions have to be
  * checked.
  *
  * @param {HTMLElement} target the conditions target

--- a/tests/form/test_dsl.py
+++ b/tests/form/test_dsl.py
@@ -23,13 +23,13 @@ class NestedFormModel(FormModel):
 
 
 def test_SimpleFormModel_should_render_correct_form() -> None:
-    assert SimpleFormModel.form() == OptionsFormDefinition(
+    assert SimpleFormModel.qpy_form == OptionsFormDefinition(
         general=[TextInputElement(name="input", label="My Text Input", required=True)]
     )
 
 
 def test_NestedFormModel_should_render_correct_form() -> None:
-    assert NestedFormModel.form() == OptionsFormDefinition(
+    assert NestedFormModel.qpy_form == OptionsFormDefinition(
         general=[
             TextInputElement(name="general_field", label="General Text Input", required=False),
             GroupElement(
@@ -88,8 +88,7 @@ def test_should_render_correct_form(initializer: object, expected_elements: List
         # mypy crashes without the type annotation
         field: Any = initializer
 
-    form = TheModel.form()
-    assert form.general == expected_elements
+    assert expected_elements == TheModel.qpy_form.general
 
 
 @pytest.mark.parametrize("annotation,initializer,input_value,expected_result", [
@@ -210,11 +209,3 @@ def test_should_raise_TypeError_when_annotation_is_wrong(annotation: object, ini
         class TheModel(FormModel):
             # pylint: disable=unused-variable
             field: annotation = initializer  # type: ignore[valid-type]
-
-
-def test_should_raise_ValueError_when_condition_target_does_not_exist() -> None:
-    with pytest.raises(ValueError, match="Element .+name='field'.+ has a condition of kind 'is_not_checked' which "
-                                         "references nonexistent element 'has_name'"):
-        class TheModel(FormModel):
-            # pylint: disable=unused-variable
-            field: Optional[str] = text_input("Your Name", disable_if=is_not_checked("has_name"), required=True)

--- a/tests/form/test_validation.py
+++ b/tests/form/test_validation.py
@@ -1,0 +1,83 @@
+import re
+
+import pytest
+from questionpy_common.elements import OptionsFormDefinition, StaticTextElement, FormSection, \
+    CheckboxElement, RepetitionElement, TextInputElement
+
+from questionpy.form import is_checked, equals
+from questionpy.form.validation import FormReferenceError, validate_form, FormError
+
+
+def test_should_not_raise_when_form_is_valid() -> None:
+    form = OptionsFormDefinition(
+        general=[CheckboxElement(name="chk1", hide_if=[is_checked("sect[chk2]")])],
+        sections=[FormSection(name="sect", header="",
+                              elements=[CheckboxElement(name="chk2", disable_if=[equals("..[chk1]", True)])])]
+    )
+
+    validate_form(form)
+
+
+def test_should_raise_FormReferenceError_when_node_doesnt_exist() -> None:
+    form_definition = OptionsFormDefinition(
+        general=[StaticTextElement(name="static", label="", text="", hide_if=[is_checked("sect[nonexistent]")])],
+        sections=[FormSection(name="sect", header="", elements=[])]
+    )
+
+    with pytest.raises(FormReferenceError) as exc_info:
+        validate_form(form_definition)
+
+    assert exc_info.value.node == "static"
+    assert exc_info.value.reference == "sect[nonexistent]"
+    assert exc_info.value.container_name == "sect"
+    assert exc_info.value.local_name == "nonexistent"
+
+
+def test_should_allow_reference_out_of_repetition() -> None:
+    form_definition = OptionsFormDefinition(general=[
+        CheckboxElement(name="chk"),
+        RepetitionElement(name="repetition", initial_elements=1, increment=1, elements=[
+            StaticTextElement(name="static", label="", text="", hide_if=[is_checked("..[chk]")]),
+        ])
+    ])
+
+    validate_form(form_definition)
+
+
+def test_should_allow_reference_within_repetition() -> None:
+    form_definition = OptionsFormDefinition(general=[
+        RepetitionElement(name="repetition", initial_elements=1, increment=1, elements=[
+            CheckboxElement(name="chk"),
+            StaticTextElement(name="static", label="", text="", hide_if=[is_checked("chk")]),
+        ])
+    ])
+
+    validate_form(form_definition)
+
+
+def test_should_forbid_reference_into_repetition() -> None:
+    form_definition = OptionsFormDefinition(general=[
+        StaticTextElement(name="static", label="", text="", hide_if=[is_checked("repetition[chk]")]),
+        RepetitionElement(name="repetition", initial_elements=1, increment=1, elements=[
+            CheckboxElement(name="chk")
+        ])
+    ])
+
+    with pytest.raises(FormError) as exc_info:
+        validate_form(form_definition)
+
+    assert exc_info.match(re.escape("repeated element 'repetition[chk]'"))
+    assert exc_info.value.node == "static"
+
+
+def test_should_forbid_is_checked_on_text_input() -> None:
+    form_definition = OptionsFormDefinition(general=[
+        StaticTextElement(name="static", label="", text="", hide_if=[is_checked("input")]),
+        TextInputElement(name="input", label="")
+    ])
+
+    with pytest.raises(FormError) as exc_info:
+        validate_form(form_definition)
+
+    assert exc_info.match(r"IsChecked.+is TextInputElement but must be.+CheckboxElement")
+    assert exc_info.value.node == "static"


### PR DESCRIPTION
Mehr aus Gewohnheit als mit Absicht habe ich zu der Syntax `erstes_so[dann][in][klammern]` gegriffen, wie sie auch PHP/Moodle benutzt. Wobei `einfach_mit.punkten.getrennt` ja eigentlich besser zu Python passen würde. Es wäre leicht, das umzustellen. Wie seht ihr das?

Die Funktion `validate_form` prüft, dass alle `hide_if`- und `disabled_if`-Referenzen auf ein valides Element zeigen. (Inklusive, dass IsChecked und IsNotChecked nur auf Checkboxes zeigen.) Dabei ist eine Referenz immer relativ zum _Container_, in dem sie verwendet wird, zu verstehen. Die Tests illustrieren das schon ganz gut, aber um noch ein FormModel-Beispiel zu geben:
```python
class MySectModel(FormModel):
    # Referenzen "nach oben" sind auch möglich.
    input_1 = text_input("Abc", hide_if=[is_checked("..[chk]")])

class MyMainModel(FormModel):
    chk = checkbox("Input 1 verstecken", disable_if=[does_not_equal("sect[input_1]", "")])
    sect = section(MySectModel)
```

Das Moodle-Plugin wird dann aus den relativen Referenzen absolute machen müssen. Das habe ich noch nicht angegangen.

Ich habe auch `form_elements`, `form_sections` und `form` im `FormModel` zu `qpy_form` zusammengefasst. `qpy_`, um Konflikte mit Form-Elementen zu vermeiden. Generell sollten wir zu diesem Zweck den Namespace von `FormModel` recht clean halten.

Enthält jetzt auch den einzeiligen Fix für #32.

Closes #29
Closes #32