### PR TITLE
#31: Docstrings für Form-Funktionen (die zweite)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ tox = "^4.2.6"
 questionpy-sdk = 'questionpy_sdk.__main__:cli'
 
 [tool.pytest.ini_options]
+addopts = "--doctest-modules"
 # https://github.com/pytest-dev/pytest-asyncio#auto-mode
 asyncio_mode = "auto"
 

--- a/questionpy/form/_dsl.py
+++ b/questionpy/form/_dsl.py
@@ -29,36 +29,43 @@ def _listify(value: _ZeroOrMoreConditions) -> list[Condition]:
 
 
 @overload
-def text_input(label: str, required: Literal[False] = False, *,
+def text_input(label: str, *, required: Literal[False] = False,
+               default: Optional[str] = None, placeholder: Optional[str] = None,
                disable_if: _ZeroOrMoreConditions = None, hide_if: _ZeroOrMoreConditions = None) -> Optional[str]:
     pass
 
 
 @overload
-def text_input(label: str, required: Literal[True], *,
+def text_input(label: str, *, required: Literal[True],
+               default: Optional[str] = None, placeholder: Optional[str] = None,
                disable_if: None = None, hide_if: None = None) -> str:
     pass
 
 
 @overload
-def text_input(label: str, required: bool = False, *,
+def text_input(label: str, *, required: bool = False,
+               default: Optional[str] = None, placeholder: Optional[str] = None,
                disable_if: _OneOrMoreConditions, hide_if: _ZeroOrMoreConditions = None) -> Optional[str]:
     pass
 
 
 @overload
-def text_input(label: str, required: bool = False, *,
+def text_input(label: str, *, required: bool = False,
+               default: Optional[str] = None, placeholder: Optional[str] = None,
                disable_if: _ZeroOrMoreConditions = None, hide_if: _OneOrMoreConditions) -> Optional[str]:
     pass
 
 
-def text_input(label: str, required: bool = False, *,
+def text_input(label: str, *, required: bool = False,
+               default: Optional[str] = None, placeholder: Optional[str] = None,
                disable_if: _ZeroOrMoreConditions = None, hide_if: _ZeroOrMoreConditions = None) -> Any:
     """Adds a text input field.
 
     Args:
         label: Text describing the element, shown verbatim.
         required: Require some non-empty input to be entered before the form can be submitted.
+        default: Default value of the input when first loading the form. Part of the submitted form data.
+        placeholder: Placeholder to show when no value has been entered yet. Not part of the submitted form data.
         disable_if: Disable this element if some condition(s) match.
         hide_if: Hide this element if some condition(s) match.
 
@@ -67,6 +74,7 @@ def text_input(label: str, required: bool = False, *,
     """
     return _FieldInfo(
         lambda name: TextInputElement(name=name, label=label, required=required,
+                                      default=default, placeholder=placeholder,
                                       disable_if=_listify(disable_if), hide_if=_listify(hide_if)),
         Optional[str] if not required or disable_if or hide_if else str,
         None if not required or disable_if or hide_if else ...,

--- a/questionpy/form/_dsl.py
+++ b/questionpy/form/_dsl.py
@@ -278,7 +278,7 @@ def select(label: str, enum: Type[_E], *,
 
 
 def option(label: str, selected: bool = False) -> _OptionInfo:
-    """Adds a option to an `OptionEnum`.
+    """Adds an option to an `OptionEnum`.
 
     Args:
         label: Text describing the option, shown verbatim.
@@ -286,6 +286,13 @@ def option(label: str, selected: bool = False) -> _OptionInfo:
 
     Returns:
         An internal object containing metadata about the option.
+
+    Examples:
+        >>> class ColorEnum(OptionEnum):
+        ...     RED = option("Red")
+        ...     GREEN = option("Green")
+        ...     BLUE = option("Blue")
+        ...     NONE = option("None", selected=True)
     """
     return _OptionInfo(label, selected)
 
@@ -336,6 +343,19 @@ def section(header: str, model: Type[_F]) -> _F:
 
     Returns:
         An internal object containing metadata about the section.
+
+    Examples:
+        The following replicates Moodle's "Combined feedback" section. We define a separate `FormModel` subclass
+        containing three text inputs.
+        >>> class FeedbackSection(FormModel):
+        ...     correct = text_input("For any correct response", required=True)
+        ...     partial = text_input("For any partially correct response")
+        ...     incorrect = text_input("For any incorrect response", required=True)
+
+        In our main options class, we use the `section` function, giving a header to the section and referencing our
+        sub-model.
+        >>> class Options(FormModel):
+        ...     feedback = section("Combined feedback", FeedbackSection)
     """
     # We pretend to return an instance of the model so the type of the section field can be inferred.
     return cast(_F, _SectionInfo(header, model))
@@ -353,6 +373,18 @@ def group(label: str, model: Type[_F], *,
 
     Returns:
         An internal object containing metadata about the section.
+
+    Examples:
+        This example shows a text input field directly followed by a drop-down with possible units. We define a separate
+        `FormModel` subclass which will contain our grouped inputs.
+        >>> class SizeGroup(FormModel):
+        ...     amount = text_input("Amount")
+        ...     unit = select("Unit", OptionEnum)
+
+        In our main options class, we use the `group` function, giving a label to the group and referencing our
+        sub-model.
+        >>> class Options(FormModel):
+        ...     size = group("Size", SizeGroup)
     """
     # We pretend to return an instance of the model so the type of the section field can be inferred.
     return cast(_F, _FieldInfo(
@@ -373,6 +405,18 @@ def repeat(model: Type[_F], *, initial: int = 1, increment: int = 1, button_labe
 
     Returns:
         An internal object containing metadata about the section.
+
+    Examples:
+        The following shows part of a simplified multiple-choice question. A separate sub-model defines the elements
+        which should be repeated.
+        >>> class Choice(FormModel):
+        ...     text = text_input("Choice")
+        ...     correct = checkbox("Correct")
+
+        The sub-model is referenced in the main model using the `repeat` function. In this case, we set it to repeat 3
+        times initially, and add 3 new repetitions whith each click of the button. We also customize the button's label.
+        >>> class Options(FormModel):
+        ...     choices = repeat(Choice, initial=3, increment=3, button_label="Add 3 more choices")
     """
     return cast(list[_F], _FieldInfo(
         lambda name: RepetitionElement(name=name, initial_elements=initial, increment=increment,

--- a/questionpy/form/_model.py
+++ b/questionpy/form/_model.py
@@ -17,6 +17,11 @@ class _OptionInfo:
 
 
 class OptionEnum(Enum):
+    """Enum specifying the possible options for radio groups and drop-downs.
+
+    Specify options using `option`.
+    """
+
     def __init__(self, option: _OptionInfo):
         super().__init__()
         self._value_ = self.name
@@ -168,17 +173,20 @@ class _FormModelMeta(ModelMetaclass):
                                      f"nonexistent element '{condition.name}'")
 
     def form_elements(cls) -> Iterable[FormElement]:
+        """Generator over all elements in this form. Does not include sections or elements nested in sections."""
         for field in cls.__fields__.values():
             if "form_element" in field.field_info.extra:
                 yield field.field_info.extra["form_element"]
 
     def form_sections(cls) -> Iterable[FormSection]:
+        """Generator over all sections in this form."""
         for field in cls.__fields__.values():
             if "form_section" in field.field_info.extra:
                 info: _SectionInfo = field.field_info.extra["form_section"]
                 yield FormSection(name=field.name, header=info.header, elements=list(info.model.form_elements()))
 
     def form(cls) -> OptionsFormDefinition:
+        """Builds the form definition."""
         return OptionsFormDefinition(
             general=list(cls.form_elements()),
             sections=list(cls.form_sections())
@@ -186,4 +194,9 @@ class _FormModelMeta(ModelMetaclass):
 
 
 class FormModel(BaseModel, metaclass=_FormModelMeta):
+    """Declarative form definition.
+
+    Use the DSL functions to define your elements as fields, and have submitted form data automatically validated into a
+    type-safe instance of your model.
+    """
     __slots__ = ()

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -11,11 +11,11 @@ class MyOptionEnum(OptionEnum):
 
 
 class SimpleFormModel(FormModel):
-    input: str = text_input("My Text Input", True)
+    input: str = text_input("My Text Input", required=True)
 
 
 class NestedFormModel(FormModel):
-    general_field: Optional[str] = text_input("General Text Input", False)
+    general_field: Optional[str] = text_input("General Text Input")
 
     sect = section("My Header", SimpleFormModel)
     grp = group("My Group", SimpleFormModel)
@@ -94,11 +94,11 @@ def test_should_render_correct_form(initializer: object, expected_elements: List
 
 @pytest.mark.parametrize("annotation,initializer,input_value,expected_result", [
     # text_input
-    (str, text_input("", True), "valid", "valid"),
-    (str, text_input("", True), b"coercible", "coercible"),
-    (Optional[str], text_input("", False), "valid", "valid"),
-    (Optional[str], text_input("", False), None, None),
-    (Optional[str], text_input("", False), ..., None),
+    (str, text_input("", required=True), "valid", "valid"),
+    (str, text_input("", required=True), b"coercible", "coercible"),
+    (Optional[str], text_input(""), "valid", "valid"),
+    (Optional[str], text_input(""), None, None),
+    (Optional[str], text_input(""), ..., None),
     # checkbox
     (bool, checkbox("", "", required=True), True, True),
     (bool, checkbox("", "", required=False), True, True),
@@ -144,9 +144,9 @@ def test_should_parse_correctly_when_input_is_valid(annotation: object, initiali
 
 @pytest.mark.parametrize("annotation,initializer,input_value", [
     # text_input
-    (str, text_input("", True), ...),
-    (str, text_input("", True), None),
-    (Optional[str], text_input("", False), {}),
+    (str, text_input("", required=True), ...),
+    (str, text_input("", required=True), None),
+    (Optional[str], text_input(""), {}),
     # checkbox
     (bool, checkbox("", "", required=False), 42),
     # radio_group


### PR DESCRIPTION
GitHub hat #38 geschlossen, als ich den alten `feature/form-data-from-state` gelöscht habe und lässt ihn mich niocht wieder öffnen. Also neu. Die beiden Kommentare aus dem alten sind hier eingearbeitet.

Ursprüngliche Beschreibung:

Fügt außerdem die default und placeholder-Argumente zu text_input hinzu, die fehlten hier noch, waren aber schon Teil von common und dem Plugin.

Für die CheckboxGroup gibt es noch keine DSL-Funktion. Ich bin auch nicht ganz happy damit, dass das Ding so heißt und die Checkboxen enthält, wenn es eigentlich nur einen Knopf hinzufügt. Das würde ich eher demnächst mal so ändern, dass die Checkboxes separat definiert und dann in eine CheckboxToggleElement (oder so) per Name referenziert werden.
