### PR TITLE
OptionEnum im JSON

### DIFF
--- a/tests/form/test_dsl.py
+++ b/tests/form/test_dsl.py
@@ -1,7 +1,8 @@
+import json
 from typing import Optional, List, Literal, Set, Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic import ValidationError, parse_raw_as
 
 from questionpy.form import *  # pylint: disable=wildcard-import
 
@@ -209,3 +210,11 @@ def test_should_raise_TypeError_when_annotation_is_wrong(annotation: object, ini
         class TheModel(FormModel):
             # pylint: disable=unused-variable
             field: annotation = initializer  # type: ignore[valid-type]
+
+
+def test_OptionEnum_should_serialize_to_value() -> None:
+    assert json.dumps(MyOptionEnum.OPT_1) == '"OPT_1"'
+
+
+def test_OptionEnum_should_deserialize_from_value() -> None:
+    assert parse_raw_as(MyOptionEnum, '"OPT_1"') is MyOptionEnum.OPT_1


### PR DESCRIPTION
Damit `OptionEnum`-Varianten ohne extra JSON encoder als ihre Value serialisiert werden, muss `OptionEnum` ein str sein. Um noch `label` und `selected` reinzukriegen, gibt `option()` aber ein `_OptionInfo`-Objekt zurück. Das sollte eigentlich nur bis zu `OptionEnum.__init__` leben, es stellt sich aber heraus, dass `EnumMeta.__new__` sofort `str(_OptionInfo(...))` aufruft, sodass der String-Wert `"_OptionInfo(...)"` war und das dann im JSON landete.

Um das zu lösen war es letztenendes nötig, die Metaklasse anzufassen. Da wird der `_OptionInfo` der Name hinzugefügt, sodass `__new__` ihn verwenden kann.

TL;DR: Vorher `"_OptionInfo(label=..., selected=...)"`, jetzt korrekt `"OPT_1"` im JSON.