### PR TITLE
MIT-Lizenz

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright © 2023 Technische Universität Berlin, innoCampus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build.py
+++ b/build.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from pathlib import Path
 from typing import Any
 from zipfile import ZipFile

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+#
+# This file is part of the QuestionPy SDK. (https://questionpy.org)
+# The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+# (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+#
+
 printf -- 'running flake8 \n'
 flake8 questionpy questionpy_sdk tests
 

--- a/example/python/local/example/__init__.py
+++ b/example/python/local/example/__init__.py
@@ -1,0 +1,3 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>

--- a/example/python/local/example/main.py
+++ b/example/python/local/example/main.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from questionpy import QuestionType
 from questionpy.form import *
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "questionpy-sdk"
 description = "Library and toolset for the development of QuestionPy packages"
 authors = ["innoCampus <info@isis.tu-berlin.de>"]
+license = "MIT"
 homepage = "https://questionpy.org"
 version = "0.2.0"
 packages = [

--- a/questionpy/__init__.py
+++ b/questionpy/__init__.py
@@ -1,2 +1,6 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from questionpy_common.manifest import Manifest, PackageType  # noqa
 from questionpy._qtype import QuestionType  # noqa

--- a/questionpy/_qtype.py
+++ b/questionpy/_qtype.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import json
 from typing import Any, Optional, Type, Generic, TypeVar, ClassVar, get_args, get_origin
 

--- a/questionpy/form/__init__.py
+++ b/questionpy/form/__init__.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from questionpy_common.elements import *  # noqa
 
 from ._dsl import *  # noqa

--- a/questionpy/form/_dsl.py
+++ b/questionpy/form/_dsl.py
@@ -40,6 +40,10 @@ Todo:
     - Make labels optional
 """
 
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from typing import cast, TypeVar, Any, overload, Literal, Optional, Set, Union, Type
 
 from questionpy_common.conditions import Condition, IsChecked, IsNotChecked, Equals, DoesNotEqual, In

--- a/questionpy/form/_model.py
+++ b/questionpy/form/_model.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
 from typing import Callable, Tuple, Type, Iterable, Any, get_origin, get_args, Literal, TYPE_CHECKING, Dict, \

--- a/questionpy/form/validation.py
+++ b/questionpy/form/validation.py
@@ -3,6 +3,10 @@
 The form is considered a tree whose root node is the :class:`OptionsFormDefinition` and other nodes are either form
 sections or form elements. A reference is a path from the referrer to the referent along that tree.
 """
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from itertools import chain
 from typing import Union, Sequence, Optional
 

--- a/questionpy_sdk/__init__.py
+++ b/questionpy_sdk/__init__.py
@@ -1,0 +1,3 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>

--- a/questionpy_sdk/__main__.py
+++ b/questionpy_sdk/__main__.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import logging
 import sys
 

--- a/questionpy_sdk/commands/__init__.py
+++ b/questionpy_sdk/commands/__init__.py
@@ -1,0 +1,3 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>

--- a/questionpy_sdk/commands/_helper.py
+++ b/questionpy_sdk/commands/_helper.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from questionpy_common.manifest import Manifest
 
 

--- a/questionpy_sdk/commands/create.py
+++ b/questionpy_sdk/commands/create.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import logging
 from pathlib import Path
 from typing import Optional

--- a/questionpy_sdk/commands/package.py
+++ b/questionpy_sdk/commands/package.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import inspect
 import logging
 import subprocess

--- a/questionpy_sdk/commands/repo/__init__.py
+++ b/questionpy_sdk/commands/repo/__init__.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import click
 
 from questionpy_sdk.commands.repo.structure import structure

--- a/questionpy_sdk/commands/repo/_helper.py
+++ b/questionpy_sdk/commands/repo/_helper.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from bisect import insort
 from datetime import datetime, timezone
 from pathlib import Path

--- a/questionpy_sdk/commands/repo/index.py
+++ b/questionpy_sdk/commands/repo/index.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from pathlib import Path
 
 import click

--- a/questionpy_sdk/commands/repo/structure.py
+++ b/questionpy_sdk/commands/repo/structure.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from pathlib import Path
 from shutil import copy
 

--- a/questionpy_sdk/commands/run.py
+++ b/questionpy_sdk/commands/run.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import logging
 from pathlib import Path
 

--- a/questionpy_sdk/package.py
+++ b/questionpy_sdk/package.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import logging
 from pathlib import Path
 from zipfile import ZipFile

--- a/questionpy_sdk/resources/__init__.py
+++ b/questionpy_sdk/resources/__init__.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from importlib.resources import as_file, files
 
 

--- a/questionpy_sdk/webserver/__init__.py
+++ b/questionpy_sdk/webserver/__init__.py
@@ -1,0 +1,3 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>

--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import json
 from pathlib import Path
 

--- a/questionpy_sdk/webserver/state_storage.py
+++ b/questionpy_sdk/webserver/state_storage.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import json
 from pathlib import Path
 from typing import Optional, Union, List

--- a/questionpy_sdk/webserver/static/conditions.js
+++ b/questionpy_sdk/webserver/static/conditions.js
@@ -1,3 +1,9 @@
+/*
+ * This file is part of the QuestionPy SDK. (https://questionpy.org)
+ * The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+ * (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+ */
+
 export class Types {
     constructor(value) {
         this.value = value

--- a/questionpy_sdk/webserver/static/script.js
+++ b/questionpy_sdk/webserver/static/script.js
@@ -1,3 +1,9 @@
+/*
+ * This file is part of the QuestionPy SDK. (https://questionpy.org)
+ * The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+ * (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+ */
+
 import * as conditions from "./conditions.js";
 
 

--- a/questionpy_sdk/webserver/static/styles.css
+++ b/questionpy_sdk/webserver/static/styles.css
@@ -1,3 +1,9 @@
+/*
+ * This file is part of the QuestionPy SDK. (https://questionpy.org)
+ * The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+ * (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+ */
+
 
 * {
     box-sizing: border-box;

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,3 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>

--- a/tests/cli/repo/__init__.py
+++ b/tests/cli/repo/__init__.py
@@ -1,0 +1,3 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>

--- a/tests/cli/repo/test_index.py
+++ b/tests/cli/repo/test_index.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from pathlib import Path
 
 import pytest

--- a/tests/cli/repo/test_structure.py
+++ b/tests/cli/repo/test_structure.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from pathlib import Path
 
 import pytest

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from pathlib import Path
 from filecmp import dircmp
 from zipfile import ZipFile

--- a/tests/cli/test_package.py
+++ b/tests/cli/test_package.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import os
 from pathlib import Path
 from zipfile import ZipFile

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from click.testing import CliRunner
 
 from questionpy_sdk.commands.run import run

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from pathlib import Path
 from shutil import move
 

--- a/tests/form/__init__.py
+++ b/tests/form/__init__.py
@@ -1,0 +1,3 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>

--- a/tests/form/test_dsl.py
+++ b/tests/form/test_dsl.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import json
 from typing import Optional, List, Literal, Set, Any
 

--- a/tests/form/test_validation.py
+++ b/tests/form/test_validation.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 import re
 
 import pytest

--- a/tests/test_qtype.py
+++ b/tests/test_qtype.py
@@ -1,3 +1,7 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
 from typing import Optional
 
 import pytest


### PR DESCRIPTION
Ich habe das IntelliJ-Feature für die Copyright-Notices benutzt (Settings &rarr; Editor &rarr; Copyright). Das hat den Nachteil, dass zwischen `#` und dem ersten Buchstaben aus irgendeinem Grund immer zwei Leerzeichen (statt nur einem) sind. Das lässt sich scheinbar nicht ändern. Halte ich aber für besser, als die Kommentare per hand zu pflegen.

Hier der genaue Text zum Einpflegen in IntelliJ:
```
This file is part of the QuestionPy SDK. (https://questionpy.org)
The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
(c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
```

Dann kann per Rechtsklick &rarr; `Update Copyright` der Header hinzugefügt / Aktualisiert (s.u.) werden.

Noch 1 pro Tipp: Ohne weiteres fügt jedes `Update Copyright` eine neue Kopie des Headers hinzu. Wenn man in `Regexp to detect copyright in comments` einen Teil des Textes einträgt, aktualisiert IntelliJ aber sinnvoll die Kommentare. Z.b. `\(c\) Technische Universität Berlin`