### PR TITLE
feature: shortened help parameter (-h)

### DIFF
--- a/questionpy_sdk/__main__.py
+++ b/questionpy_sdk/__main__.py
@@ -14,7 +14,7 @@ from questionpy_sdk.commands.run import run
 from questionpy_sdk.commands.repo import repo
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ['-h', '--help']})
 @click.option("-v", "--verbose", is_flag=True, show_default=True, default=False, help="Use log level DEBUG.")
 def cli(verbose: bool) -> None:
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, stream=sys.stderr)


### PR DESCRIPTION
QuestionPy SDK Commands können jetzt mit `-h` statt nur mit `-help` aufgerufen werden.