### PR TITLE
Laufende Nummer in den Form Elementen

### DIFF
--- a/example/python/local/example/form.py
+++ b/example/python/local/example/form.py
@@ -13,7 +13,7 @@ class MyOptions(OptionEnum):
 
 
 class Participants(FormModel):
-    role = select("Role:", MyOptions)
+    role = select("Participant #{ qpy:repno } Role:", MyOptions)
     name = group("Name", NameGroup)
 
 

--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -18,6 +18,7 @@ from questionpy_server.worker.worker import Worker
 from questionpy_server.worker.exception import WorkerUnknownError
 from questionpy_server.worker.worker.thread import ThreadWorker
 
+from questionpy_sdk.webserver.context import contextualize
 from questionpy_sdk.webserver.state_storage import QuestionStateStorage, add_repetition, parse_form_data
 
 routes = web.RouteTableDef()
@@ -59,8 +60,7 @@ async def render_options(request: web.Request) -> web.Response:
 
     context = {
         'manifest': manifest,
-        'options': form_definition.model_dump(),
-        'form_data': form_data
+        'options': contextualize(form_definition=form_definition, form_data=form_data).model_dump()
     }
 
     return aiohttp_jinja2.render_template('options.html.jinja2', request, context)
@@ -116,8 +116,7 @@ async def repeat_element(request: web.Request) -> web.Response:
 
     context = {
         'manifest': manifest,
-        'options': form_definition.model_dump(),
-        'form_data': form_data
+        'options': contextualize(form_definition=form_definition, form_data=form_data).model_dump()
     }
 
     return aiohttp_jinja2.render_template('options.html.jinja2', request, context)

--- a/questionpy_sdk/webserver/context.py
+++ b/questionpy_sdk/webserver/context.py
@@ -1,0 +1,92 @@
+#  This file is part of QuestionPy. (https://questionpy.org)
+#  QuestionPy is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
+from typing import List, Any, Optional, Dict
+
+from questionpy_common.elements import StaticTextElement, CheckboxElement, TextInputElement, FormElement, \
+    GroupElement, RepetitionElement, OptionsFormDefinition, CheckboxGroupElement, RadioGroupElement, SelectElement, \
+    HiddenElement
+
+from questionpy_sdk.webserver.elements import CxdOptionsFormDefinition, CxdFormSection, CxdFormElement, \
+    CxdGroupElement, CxdRepetitionElement, CxdStaticTextElement, CxdTextInputElement, \
+    CxdCheckboxElement, CxdCheckboxGroupElement, CxdRadioGroupElement, CxdSelectElement, CxdHiddenElement
+
+element_mapping: Dict[type, type] = {
+    StaticTextElement: CxdStaticTextElement,
+    TextInputElement: CxdTextInputElement,
+    CheckboxElement: CxdCheckboxElement,
+    CheckboxGroupElement: CxdCheckboxGroupElement,
+    RadioGroupElement: CxdRadioGroupElement,
+    SelectElement: CxdSelectElement,
+    HiddenElement: CxdHiddenElement
+}
+
+
+def _contextualize_element(element: FormElement, form_data: Optional[dict[str, Any]], path: List[str],
+                           context: Optional[dict] = None) -> CxdFormElement:
+    path.append(element.name)
+    element_form_data = None
+    if form_data:
+        element_form_data = form_data.get(element.name)
+
+    if isinstance(element, GroupElement):
+        cxd_gr_element = CxdGroupElement(path=path.copy(), **element.model_dump(exclude={'elements'}))
+        cxd_gr_element.cxd_elements = _contextualize_element_list(element.elements, element_form_data, path)
+        path.pop()
+        return cxd_gr_element
+
+    if isinstance(element, RepetitionElement):
+        cxd_rep_element = CxdRepetitionElement(path=path.copy(), **element.model_dump(exclude={'elements'}))
+        if not element_form_data:
+            for i in range(element.initial_repetitions):
+                path.append(str(i))
+                element_list = _contextualize_element_list(element.elements, None, path, {'repno': i})
+                cxd_rep_element.cxd_elements.append(element_list)
+                path.pop()
+            path.pop()
+            return cxd_rep_element
+        for i, repetition in enumerate(element_form_data):
+            path.append(str(i))
+            element_list = _contextualize_element_list(element.elements, repetition, path, {'repno': i})
+            cxd_rep_element.cxd_elements.append(element_list)
+            path.pop()
+        path.pop()
+        return cxd_rep_element
+
+    if element.__class__ not in element_mapping:
+        raise ValueError(f"No corresponding CxdFormElement found for {element.__class__}")
+
+    cxd_element_class = element_mapping[element.__class__]
+    cxd_element = cxd_element_class(**element.model_dump(), path=path)
+    if context:
+        cxd_element.contextualize(context.get('repno'))
+    cxd_element.add_form_data_value(element_form_data)
+
+    path.pop()
+    return cxd_element
+
+
+def _contextualize_element_list(element_list: List[FormElement], form_data: Optional[dict[str, Any]],
+                                path: list[str], context: Optional[dict] = None) -> List[CxdFormElement]:
+    cxd_element_list: List[CxdFormElement] = []
+    for element in element_list:
+        cxd_element = _contextualize_element(element, form_data, path, context)
+        cxd_element_list.append(cxd_element)
+    return cxd_element_list
+
+
+def contextualize(form_definition: OptionsFormDefinition, form_data: Optional[dict[str, Any]]) \
+        -> CxdOptionsFormDefinition:
+    path: list[str] = ['general']
+    cxd_options_form = CxdOptionsFormDefinition()
+    cxd_options_form.general = _contextualize_element_list(form_definition.general, form_data, path)
+    for section in form_definition.sections:
+        path = [section.name]
+        cxd_section = CxdFormSection(name=section.name, header=section.header, path=path)
+        section_data = None
+        if form_data:
+            section_data = form_data.get(section.name)
+        cxd_section.cxd_elements = _contextualize_element_list(section.elements, section_data, path)
+        cxd_options_form.sections.append(cxd_section)
+    return cxd_options_form

--- a/questionpy_sdk/webserver/context.py
+++ b/questionpy_sdk/webserver/context.py
@@ -60,7 +60,7 @@ def _contextualize_element(element: FormElement, form_data: Optional[dict[str, A
     cxd_element_class = element_mapping[element.__class__]
     cxd_element = cxd_element_class(**element.model_dump(), path=path)
     if context:
-        cxd_element.contextualize(context.get('repno'))
+        cxd_element.contextualize(r'\{\s?qpy:repno\s?\}', context.get('repno'))
     cxd_element.add_form_data_value(element_form_data)
 
     path.pop()

--- a/questionpy_sdk/webserver/context.py
+++ b/questionpy_sdk/webserver/context.py
@@ -55,9 +55,9 @@ def _contextualize_element(element: FormElement, form_data: Optional[dict[str, A
         return cxd_rep_element
 
     if type(element) not in element_mapping:
-        raise ValueError(f"No corresponding CxdFormElement found for {element.__class__}")
+        raise ValueError(f"No corresponding CxdFormElement found for {type(element)}")
 
-    cxd_element_class = element_mapping[element.__class__]
+    cxd_element_class = element_mapping[type(element)]
     cxd_element = cxd_element_class(**element.model_dump(), path=path)
     if context:
         cxd_element.contextualize(r'\{\s?qpy:repno\s?\}', str(context.get('repno')))

--- a/questionpy_sdk/webserver/context.py
+++ b/questionpy_sdk/webserver/context.py
@@ -32,7 +32,7 @@ def _contextualize_element(element: FormElement, form_data: Optional[dict[str, A
 
     if isinstance(element, GroupElement):
         cxd_gr_element = CxdGroupElement(path=path.copy(), **element.model_dump(exclude={'elements'}))
-        cxd_gr_element.cxd_elements = _contextualize_element_list(element.elements, element_form_data, path)
+        cxd_gr_element.cxd_elements = _contextualize_element_list(element.elements, element_form_data, path, context)
         path.pop()
         return cxd_gr_element
 

--- a/questionpy_sdk/webserver/elements.py
+++ b/questionpy_sdk/webserver/elements.py
@@ -129,6 +129,8 @@ class CxdSelectElement(SelectElement, _CxdFormElement):
 
     def contextualize(self, text: str) -> None:
         self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+        for cxd_option in self.cxd_options:
+            cxd_option.contextualize(text)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if not element_form_data:

--- a/questionpy_sdk/webserver/elements.py
+++ b/questionpy_sdk/webserver/elements.py
@@ -2,7 +2,7 @@
 #  QuestionPy is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
-import re
+from re import sub, Pattern
 from typing import List, Union, Annotated, Any, Optional
 from typing_extensions import TypeAlias
 from pydantic import Field, BaseModel
@@ -13,11 +13,17 @@ from questionpy_common.elements import StaticTextElement, GroupElement, HiddenEl
 from questionpy_common.elements import FormElement  # noqa: F401
 
 
+def replace(pattern: Pattern[str], replacement: str, string: str) -> str:
+    if not string:
+        return ""
+    return sub(pattern, f'{replacement}', string)
+
+
 class _CxdFormElement(BaseModel):
     path: list[str]
     id: str = ''
 
-    def contextualize(self, text: str) -> None:
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
         pass
 
     def add_form_data_value(self, element_form_data: Any) -> None:
@@ -27,10 +33,10 @@ class _CxdFormElement(BaseModel):
 class CxdTextInputElement(TextInputElement, _CxdFormElement):
     value: Optional[str] = None
 
-    def contextualize(self, text: str) -> None:
-        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
-        self.default = re.sub(r'\{ qpy:repno }', f'{text}', self.default)
-        self.placeholder = re.sub(r'\{ qpy:repno }', f'{text}', self.placeholder)
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
+        self.label = replace(pattern, replacement, self.label)
+        self.default = replace(pattern, replacement, self.default)
+        self.placeholder = replace(pattern, replacement, self.placeholder)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if element_form_data:
@@ -39,15 +45,15 @@ class CxdTextInputElement(TextInputElement, _CxdFormElement):
 
 class CxdStaticTextElement(StaticTextElement, _CxdFormElement):
 
-    def contextualize(self, text: str) -> None:
-        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
-        self.text = re.sub(r'\{ qpy:repno }', f'{text}', self.text)
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
+        self.label = replace(pattern, replacement, self.label)
+        self.text = replace(pattern, replacement, self.text)
 
 
 class CxdCheckboxElement(CheckboxElement, _CxdFormElement):
-    def contextualize(self, text: str) -> None:
-        self.left_label = re.sub(r'\{ qpy:repno }', f'{text}', self.left_label)
-        self.right_label = re.sub(r'\{ qpy:repno }', f'{text}', self.right_label)
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
+        self.left_label = replace(pattern, replacement, self.left_label)
+        self.right_label = replace(pattern, replacement, self.right_label)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if element_form_data:
@@ -68,9 +74,9 @@ class CxdCheckboxGroupElement(CheckboxGroupElement, _CxdFormElement):
             path.pop()
         self.checkboxes = []
 
-    def contextualize(self, text: str) -> None:
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
         for cxd_checkbox in self.cxd_checkboxes:
-            cxd_checkbox.contextualize(text)
+            cxd_checkbox.contextualize(pattern, replacement)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if not element_form_data:
@@ -82,8 +88,8 @@ class CxdCheckboxGroupElement(CheckboxGroupElement, _CxdFormElement):
 
 
 class CxdOption(Option, _CxdFormElement):
-    def contextualize(self, text: str) -> None:
-        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
+        self.label = replace(pattern, replacement, self.label)
 
 
 class CxdRadioGroupElement(RadioGroupElement, _CxdFormElement):
@@ -100,10 +106,10 @@ class CxdRadioGroupElement(RadioGroupElement, _CxdFormElement):
             path.pop()
         self.options = []
 
-    def contextualize(self, text: str) -> None:
-        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
+        self.label = replace(pattern, replacement, self.label)
         for cxd_option in self.cxd_options:
-            cxd_option.contextualize(text)
+            cxd_option.contextualize(pattern, replacement)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if not element_form_data:
@@ -127,10 +133,10 @@ class CxdSelectElement(SelectElement, _CxdFormElement):
             path.pop()
         self.options = []
 
-    def contextualize(self, text: str) -> None:
-        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
+        self.label = replace(pattern, replacement, self.label)
         for cxd_option in self.cxd_options:
-            cxd_option.contextualize(text)
+            cxd_option.contextualize(pattern, replacement, )
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if not element_form_data:
@@ -142,7 +148,7 @@ class CxdSelectElement(SelectElement, _CxdFormElement):
 
 
 class CxdHiddenElement(HiddenElement, _CxdFormElement):
-    def contextualize(self, text: str) -> None:
+    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
         pass
 
     def add_form_data_value(self, element_form_data: Any) -> None:

--- a/questionpy_sdk/webserver/elements.py
+++ b/questionpy_sdk/webserver/elements.py
@@ -1,0 +1,180 @@
+#  This file is part of QuestionPy. (https://questionpy.org)
+#  QuestionPy is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
+import re
+from typing import List, Union, Annotated, Any, Optional
+from typing_extensions import TypeAlias
+from pydantic import Field, BaseModel
+
+from questionpy_common.elements import StaticTextElement, GroupElement, HiddenElement, RepetitionElement, \
+    SelectElement, RadioGroupElement, Option, CheckboxGroupElement, CheckboxElement, TextInputElement, FormSection
+# pylint: disable=unused-import
+from questionpy_common.elements import FormElement  # noqa: F401
+
+
+class _CxdFormElement(BaseModel):
+    path: list[str]
+    id: str = ''
+
+    def contextualize(self, text: str) -> None:
+        pass
+
+    def add_form_data_value(self, element_form_data: Any) -> None:
+        pass
+
+
+class CxdTextInputElement(TextInputElement, _CxdFormElement):
+    value: Optional[str] = None
+
+    def contextualize(self, text: str) -> None:
+        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+        self.default = re.sub(r'\{ qpy:repno }', f'{text}', self.default)
+        self.placeholder = re.sub(r'\{ qpy:repno }', f'{text}', self.placeholder)
+
+    def add_form_data_value(self, element_form_data: Any) -> None:
+        if element_form_data:
+            self.value = element_form_data
+
+
+class CxdStaticTextElement(StaticTextElement, _CxdFormElement):
+
+    def contextualize(self, text: str) -> None:
+        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+        self.text = re.sub(r'\{ qpy:repno }', f'{text}', self.text)
+
+
+class CxdCheckboxElement(CheckboxElement, _CxdFormElement):
+    def contextualize(self, text: str) -> None:
+        self.left_label = re.sub(r'\{ qpy:repno }', f'{text}', self.left_label)
+        self.right_label = re.sub(r'\{ qpy:repno }', f'{text}', self.right_label)
+
+    def add_form_data_value(self, element_form_data: Any) -> None:
+        if element_form_data:
+            self.selected = element_form_data
+
+
+class CxdCheckboxGroupElement(CheckboxGroupElement, _CxdFormElement):
+    cxd_checkboxes: List[CxdCheckboxElement] = []
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        for checkbox in self.checkboxes:
+            path = data.get('path')
+            if not isinstance(path, list):
+                raise TypeError(f"Path should be of type list but is {type(path)}")
+            path.append(checkbox.name)
+            self.cxd_checkboxes.append(CxdCheckboxElement(**checkbox.model_dump(), path=path))
+            path.pop()
+        self.checkboxes = []
+
+    def contextualize(self, text: str) -> None:
+        for cxd_checkbox in self.cxd_checkboxes:
+            cxd_checkbox.contextualize(text)
+
+    def add_form_data_value(self, element_form_data: Any) -> None:
+        if not element_form_data:
+            return
+        selected_checkboxes = [chk for chk in self.cxd_checkboxes if chk.name in element_form_data]
+
+        for checkbox in self.cxd_checkboxes:
+            checkbox.selected = checkbox in selected_checkboxes
+
+
+class CxdOption(Option, _CxdFormElement):
+    def contextualize(self, text: str) -> None:
+        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+
+
+class CxdRadioGroupElement(RadioGroupElement, _CxdFormElement):
+    cxd_options: List[CxdOption] = []
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        for option in self.options:
+            path = data.get('path')
+            if not isinstance(path, list):
+                raise TypeError(f"Path should be of type list but is {type(path)}")
+            path.append(option.value)
+            self.cxd_options.append(CxdOption(**option.model_dump(), path=path))
+            path.pop()
+        self.options = []
+
+    def contextualize(self, text: str) -> None:
+        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+        for cxd_option in self.cxd_options:
+            cxd_option.contextualize(text)
+
+    def add_form_data_value(self, element_form_data: Any) -> None:
+        if not element_form_data:
+            return
+
+        for option in self.cxd_options:
+            option.selected = option.value == element_form_data
+
+
+class CxdSelectElement(SelectElement, _CxdFormElement):
+    cxd_options: List[CxdOption] = []
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        for option in self.options:
+            path = data.get('path')
+            if not isinstance(path, list):
+                raise TypeError(f"Path should be of type list but is {type(path)}")
+            path.append(option.value)
+            self.cxd_options.append(CxdOption(**option.model_dump(), path=path))
+            path.pop()
+        self.options = []
+
+    def contextualize(self, text: str) -> None:
+        self.label = re.sub(r'\{ qpy:repno }', f'{text}', self.label)
+
+    def add_form_data_value(self, element_form_data: Any) -> None:
+        if not element_form_data:
+            return
+        selected_options = [opt for opt in self.cxd_options if opt.value in element_form_data]
+
+        for option in self.cxd_options:
+            option.selected = option in selected_options
+
+
+class CxdHiddenElement(HiddenElement, _CxdFormElement):
+    def contextualize(self, text: str) -> None:
+        pass
+
+    def add_form_data_value(self, element_form_data: Any) -> None:
+        if element_form_data:
+            self.value = element_form_data
+
+
+class CxdGroupElement(GroupElement, _CxdFormElement):
+    cxd_elements: List["CxdFormElement"] = []
+
+    def __init__(self, **data: Any):
+        super().__init__(**data, elements=[])
+
+
+class CxdRepetitionElement(RepetitionElement, _CxdFormElement):
+    cxd_elements: list[list["CxdFormElement"]] = []
+
+    def __init__(self, **data: Any):
+        super().__init__(**data, elements=[])
+
+
+CxdFormElement: TypeAlias = Annotated[Union[
+    CxdStaticTextElement, CxdTextInputElement, CxdCheckboxElement, CxdCheckboxGroupElement,
+    CxdRadioGroupElement, CxdSelectElement, CxdHiddenElement, CxdGroupElement, CxdRepetitionElement
+], Field(discriminator="kind")]
+
+
+class CxdFormSection(FormSection):
+    cxd_elements: List[CxdFormElement] = []
+    """Elements contained in the section."""
+
+
+class CxdOptionsFormDefinition(BaseModel):
+    general: List[CxdFormElement] = []
+    """Elements to add to the main section, after the LMS' own elements."""
+    sections: List[CxdFormSection] = []
+    """Sections to add after the main section."""

--- a/questionpy_sdk/webserver/elements.py
+++ b/questionpy_sdk/webserver/elements.py
@@ -100,10 +100,9 @@ class CxdCheckboxGroupElement(CheckboxGroupElement, _CxdFormElement):
     def add_form_data_value(self, element_form_data: Any) -> None:
         if not element_form_data:
             return
-        selected_checkboxes = [chk for chk in self.cxd_checkboxes if chk.name in element_form_data]
 
         for checkbox in self.cxd_checkboxes:
-            checkbox.selected = checkbox in selected_checkboxes
+            checkbox.selected = checkbox.name in element_form_data
 
 
 class CxdOption(Option, _CxdFormElement):
@@ -160,16 +159,12 @@ class CxdSelectElement(SelectElement, _CxdFormElement):
     def add_form_data_value(self, element_form_data: Any) -> None:
         if not element_form_data:
             return
-        selected_options = [opt for opt in self.cxd_options if opt.value in element_form_data]
 
         for option in self.cxd_options:
-            option.selected = option in selected_options
+            option.selected = option.value in element_form_data
 
 
 class CxdHiddenElement(HiddenElement, _CxdFormElement):
-    def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
-        pass
-
     def add_form_data_value(self, element_form_data: Any) -> None:
         if element_form_data:
             self.value = element_form_data

--- a/questionpy_sdk/webserver/elements.py
+++ b/questionpy_sdk/webserver/elements.py
@@ -50,8 +50,10 @@ class CxdTextInputElement(TextInputElement, _CxdFormElement):
 
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
         self.label = sub(pattern, replacement, self.label)
-        self.default = sub(pattern, replacement, self.default)
-        self.placeholder = sub(pattern, replacement, self.placeholder)
+        if self.default:
+            self.default = sub(pattern, replacement, self.default)
+        if self.placeholder:
+            self.placeholder = sub(pattern, replacement, self.placeholder)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if element_form_data:
@@ -67,8 +69,10 @@ class CxdStaticTextElement(StaticTextElement, _CxdFormElement):
 
 class CxdCheckboxElement(CheckboxElement, _CxdFormElement):
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
-        self.left_label = sub(pattern, replacement, self.left_label)
-        self.right_label = sub(pattern, replacement, self.right_label)
+        if self.left_label:
+            self.left_label = sub(pattern, replacement, self.left_label)
+        if self.right_label:
+            self.right_label = sub(pattern, replacement, self.right_label)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if element_form_data:

--- a/questionpy_sdk/webserver/elements.py
+++ b/questionpy_sdk/webserver/elements.py
@@ -13,20 +13,35 @@ from questionpy_common.elements import StaticTextElement, GroupElement, HiddenEl
 from questionpy_common.elements import FormElement  # noqa: F401
 
 
-def replace(pattern: Pattern[str], replacement: str, string: str) -> str:
-    if not string:
-        return ""
-    return sub(pattern, f'{replacement}', string)
-
-
 class _CxdFormElement(BaseModel):
     path: list[str]
     id: str = ''
 
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
+        """
+        QuestionPy FormElements can contain a Pattern in their model fields which is replaced with a value when
+        the OptionsForm is presented to add additional context for the user.
+        Replaces the QPy pattern with the replacement string in model fields which can contain such a pattern.
+
+        Args:
+            pattern: The QPy Pattern to be replaced. A valid QPy Pattern matches '{qpy:<identifier>}'
+                e.g. '{qpy:repno}'
+            replacement: The replacement string
+        Returns:
+            None
+        """
         pass
 
     def add_form_data_value(self, element_form_data: Any) -> None:
+        """
+        If there is prior form data available, this data is used to set the CxdFormElements value or 'selected' state.
+
+        Args:
+            element_form_data: Any form data fitting this CxdFormElement
+
+        Returns:
+            None
+        """
         pass
 
 
@@ -34,9 +49,9 @@ class CxdTextInputElement(TextInputElement, _CxdFormElement):
     value: Optional[str] = None
 
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
-        self.label = replace(pattern, replacement, self.label)
-        self.default = replace(pattern, replacement, self.default)
-        self.placeholder = replace(pattern, replacement, self.placeholder)
+        self.label = sub(pattern, replacement, self.label)
+        self.default = sub(pattern, replacement, self.default)
+        self.placeholder = sub(pattern, replacement, self.placeholder)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if element_form_data:
@@ -46,14 +61,14 @@ class CxdTextInputElement(TextInputElement, _CxdFormElement):
 class CxdStaticTextElement(StaticTextElement, _CxdFormElement):
 
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
-        self.label = replace(pattern, replacement, self.label)
-        self.text = replace(pattern, replacement, self.text)
+        self.label = sub(pattern, replacement, self.label)
+        self.text = sub(pattern, replacement, self.text)
 
 
 class CxdCheckboxElement(CheckboxElement, _CxdFormElement):
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
-        self.left_label = replace(pattern, replacement, self.left_label)
-        self.right_label = replace(pattern, replacement, self.right_label)
+        self.left_label = sub(pattern, replacement, self.left_label)
+        self.right_label = sub(pattern, replacement, self.right_label)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if element_form_data:
@@ -89,7 +104,7 @@ class CxdCheckboxGroupElement(CheckboxGroupElement, _CxdFormElement):
 
 class CxdOption(Option, _CxdFormElement):
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
-        self.label = replace(pattern, replacement, self.label)
+        self.label = sub(pattern, replacement, self.label)
 
 
 class CxdRadioGroupElement(RadioGroupElement, _CxdFormElement):
@@ -107,7 +122,7 @@ class CxdRadioGroupElement(RadioGroupElement, _CxdFormElement):
         self.options = []
 
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
-        self.label = replace(pattern, replacement, self.label)
+        self.label = sub(pattern, replacement, self.label)
         for cxd_option in self.cxd_options:
             cxd_option.contextualize(pattern, replacement)
 
@@ -134,9 +149,9 @@ class CxdSelectElement(SelectElement, _CxdFormElement):
         self.options = []
 
     def contextualize(self, pattern: Pattern[str], replacement: str) -> None:
-        self.label = replace(pattern, replacement, self.label)
+        self.label = sub(pattern, replacement, self.label)
         for cxd_option in self.cxd_options:
-            cxd_option.contextualize(pattern, replacement, )
+            cxd_option.contextualize(pattern, replacement)
 
     def add_form_data_value(self, element_form_data: Any) -> None:
         if not element_form_data:

--- a/questionpy_sdk/webserver/templates/elements/checkbox.html.jinja2
+++ b/questionpy_sdk/webserver/templates/elements/checkbox.html.jinja2
@@ -1,28 +1,28 @@
 {% extends "elements/element.html.jinja2" %}
 
 {% block info %}
-    {% if element_options.left_label %}
-        <p class="element-label">{{ element_options.left_label }}{{ '*' if element_options.required }}</p>
+    {% if element.left_label %}
+        <p class="element-label">{{ element.left_label }}{{ '*' if element.required }}</p>
     {% endif %}
-    {% if element_options.help %}
-        {% if element_options.left_label %}
-        	{{ macros.create_icon_container(element_options.left_label, element_options.help) }}
-        {% elif element_options.right_label %}
-            {{ macros.create_icon_container(element_options.right_label, element_options.help) }}
+    {% if element.help %}
+        {% if element.left_label %}
+        	{{ macros.create_icon_container(element.left_label, element.help) }}
+        {% elif element.right_label %}
+            {{ macros.create_icon_container(element.right_label, element.help) }}
         {% endif %}
     {% endif %}
 {% endblock %}
 
 {% block content %}
     <label class="answer-label">
-        <input class="answer-checkbox" type="checkbox" id="{{ section_name }}_{{ element_options.name }}"
+        <input class="answer-checkbox" type="checkbox" id="{{ element.id }}"
                 name="{{ element_reference }}"
-                {{ {'data-absolute_path': absolute_path|tojson|forceescape}|xmlattr }}
-                {{ 'required' if element_options.required }}
-                {{ 'checked' if element_options.selected and not form_data
-                    or form_data is defined and form_data}}>
-        {% if element_options.right_label %}
-            {{ element_options.right_label }}{{ '*' if element_options.required }}
+                {{ {'data-absolute_path': element.path|tojson|forceescape}|xmlattr }}
+                {{ 'required' if element.required }}
+                {{ 'checked' if element.selected and not element.value
+                    or element.value is defined and element.value}}>
+        {% if element.right_label %}
+            {{ element.right_label }}{{ '*' if element.required }}
         {% endif %}
     </label>
 {% endblock %}

--- a/questionpy_sdk/webserver/templates/elements/checkbox_group.html.jinja2
+++ b/questionpy_sdk/webserver/templates/elements/checkbox_group.html.jinja2
@@ -2,10 +2,10 @@
 
 {% block element %}
     {# TODO: see https://moodledev.io/docs/apis/subsystems/form/advanced/checkbox-controller #}
-    <div class="element {{ element_options.kind }}"
-        {{ {'data-hide_if': element_options.hide_if|tojson|forceescape}|xmlattr if element_options.hide_if}}
-        {{ {'data-disable_if': element_options.disable_if|tojson|forceescape}|xmlattr if element_options.disable_if}}>
-        {% for checkbox_element in element_options.checkboxes %}
+    <div class="element {{ element.definition.kind }}"
+        {{ {'data-hide_if': element.definition.hide_if|tojson|forceescape}|xmlattr if element.definition.hide_if}}
+        {{ {'data-disable_if': element.definition.disable_if|tojson|forceescape}|xmlattr if element.definition.disable_if}}>
+        {% for checkbox_element in element.definition.checkboxes %}
 
             <div class="info">
                 {% if checkbox_element.left_label %}
@@ -15,10 +15,10 @@
 
             <div class="answer-option">
                 <label class="answer-label">
-                    <input class="answer-checkbox" type="checkbox" id="{{ checkbox_element.name }}"
-                            {{ 'required' if element_options.required }}
-                            {{ 'checked' if element_options.selected and not form_data
-                                or form_data is defined and form_data}}>
+                    <input class="answer-checkbox" type="checkbox" id="{{ checkbox_element.id }}"
+                            {{ 'required' if checkbox_element.required }}
+                            {{ 'checked' if checkbox_element.selected and not element.value
+                                or element.value is defined and element.value}}>
                     {% if checkbox_element.right_label %}
                         {{ checkbox_element.right_label }}
                     {% endif %}

--- a/questionpy_sdk/webserver/templates/elements/element.html.jinja2
+++ b/questionpy_sdk/webserver/templates/elements/element.html.jinja2
@@ -1,16 +1,16 @@
 {% import "./macros.jinja2" as macros %}
 
 {% block element %}
-<div class="element {{ element_options.kind }}" id="el_{{ element_id }}"
-        data-section="{{section_name}}"
-        {{ {'data-absolute_path': absolute_path|tojson|forceescape}|xmlattr }}
-        {{ {'data-hide_if': element_options.hide_if|tojson|forceescape}|xmlattr if element_options.hide_if}}
-        {{ {'data-disable_if': element_options.disable_if|tojson|forceescape}|xmlattr if element_options.disable_if}}>
+<div class="element {{ element.kind }}" id="{{ element.id }}"
+        data-section="{{ element.path[0] }}"
+        {{ {'data-absolute_path': element.path|tojson|forceescape}|xmlattr }}
+        {{ {'data-hide_if': element.hide_if|tojson|forceescape}|xmlattr if element.hide_if}}
+        {{ {'data-disable_if': element.disable_if|tojson|forceescape}|xmlattr if element.disable_if}}>
     <div class="info">
         {% block info %}
-            <p class="element-label">{{ element_options.label }}{{ '*' if element_options.required }}</p>
-            {% if element_options.help %}
-                {{ macros.create_icon_container(element_options.label, element_options.help) }}
+            <p class="element-label">{{ element.label }}{{ '*' if element.required }}</p>
+            {% if element.help %}
+                {{ macros.create_icon_container(element.label, element.help) }}
             {% endif %}
         {% endblock %}
     </div>

--- a/questionpy_sdk/webserver/templates/elements/hidden.html.jinja2
+++ b/questionpy_sdk/webserver/templates/elements/hidden.html.jinja2
@@ -1,15 +1,15 @@
 {% extends "elements/element.html.jinja2" %}
 
 {% block element %}
-<div class="element {{ element_options.kind }}" id="el_{{ element_id }}"
-        data-section="{{section_name}}" style="display: none"
-        {{ {'data-absolute_path': absolute_path|tojson|forceescape}|xmlattr }}
-        {{ {'data-hide_if': element_options.hide_if|tojson|forceescape}|xmlattr if element_options.hide_if}}
-        {{ {'data-disable_if': element_options.disable_if|tojson|forceescape}|xmlattr if element_options.disable_if}}>
+<div class="element {{ element.kind }}" id="{{ element.id }}"
+        data-section="{{ element.path[0] }}" style="display: none"
+        {{ {'data-absolute_path': element.path|tojson|forceescape}|xmlattr }}
+        {{ {'data-hide_if': element.hide_if|tojson|forceescape}|xmlattr if element.hide_if}}
+        {{ {'data-disable_if': element.disable_if|tojson|forceescape}|xmlattr if element.disable_if}}>
     <div class="content">
         {% block content %}
             <input class="input-hidden" type="hidden" name="{{ element_reference }}"
-                   value="{{ element_options.value }}" id="{{ element_id }}">
+                   value="{{ element.value }}" id="{{ element.id }}">
         {% endblock %}
     </div>
 </div>

--- a/questionpy_sdk/webserver/templates/elements/input.html.jinja2
+++ b/questionpy_sdk/webserver/templates/elements/input.html.jinja2
@@ -2,11 +2,11 @@
 
 {% block content %}
     <span class="input-span">
-        <input class="input-text" id="{{ element_id }}" name="{{ element_reference }}"
-            {{ {'placeholder': element_options.placeholder}|xmlattr if element_options.placeholder }}
-            {{ 'required' if element_options.required }}
-            {{ 'checked' if element_options.selected }}
-            {{ {'value': form_data}|xmlattr if form_data }}
-            {{ {'data-absolute_path': absolute_path|tojson|forceescape}|xmlattr }}>
+        <input class="input-text" id="{{ element.id }}" name="{{ element_reference }}"
+            {{ {'placeholder': element.placeholder}|xmlattr if element.placeholder }}
+            {{ 'required' if element.required }}
+            {{ 'checked' if element.selected }}
+            {{ {'value': element.value}|xmlattr if element.value }}
+            {{ {'data-absolute_path': element.path|tojson|forceescape}|xmlattr }}>
     </span>
 {% endblock %}

--- a/questionpy_sdk/webserver/templates/elements/radio_group.html.jinja2
+++ b/questionpy_sdk/webserver/templates/elements/radio_group.html.jinja2
@@ -1,16 +1,16 @@
 {% extends "elements/element.html.jinja2" %}
 
 {% block content %}
-    <fieldset id="{{ element_id}}">
-        {% for option in element_options.options %}
+    <fieldset id="{{ element.id}}">
+        {% for option in element.cxd_options %}
             <div class="answer-option">
                 <label class="answer-label">
-                    <input type="radio" class="answer-{{ element_options.kind }}"
-                            id="{{ element_id ~ "-" ~ option.value }}" value="{{ option.value }}"
+                    <input type="radio" class="answer-{{ element.kind }}"
+                            id="{{ element.id ~ "-" ~ option.value }}" value="{{ option.value }}"
                             name="{{ element_reference }}"
-                            {{ 'checked' if option.selected and not form_data
-                                or form_data is defined and form_data == option.value}}
-                            {{ {'data-absolute_path': absolute_path|tojson|forceescape}|xmlattr }}>
+                            {{ 'checked' if option.selected and not element.value
+                                or element.value is defined and element.value == option.value}}
+                            {{ {'data-absolute_path': element.path|tojson|forceescape}|xmlattr }}>
                     {{ option.label }}
                 </label>
             </div>

--- a/questionpy_sdk/webserver/templates/elements/select.html.jinja2
+++ b/questionpy_sdk/webserver/templates/elements/select.html.jinja2
@@ -1,22 +1,22 @@
 {% extends "elements/element.html.jinja2" %}
 
 {% block content %}
-    {% if element_options.multiple and element_options.multiple == True %}
+    {% if element.multiple and element.multiple == True %}
         {% set element_reference = element_reference + '_[]' %}
     {% endif %}
-   <select class="answer-{{ element_options.kind }}" name="{{ element_reference }}"
-    {{ 'multiple' if element_options.multiple and element_options.multiple == True }}>
+   <select class="answer-{{ element.kind }}" name="{{ element_reference }}"
+    {{ 'multiple' if element.multiple and element.multiple == True }}>
 {# TODO: sollen wir diese Aufforderung drin lassen wenn required=false ist? Dann müssen wir auch was im _dsl #}
 {# TODO: ändern sonst werden die Options falsch geparsed  #}
-{#        {% if not element_options.required %}#}
+{#        {% if not element.required %}#}
 {#            <option value="">--Please choose an option--</option>#}
 {#        {% endif %}#}
-       {% set option_id = absolute_path %}
-        {% for option in element_options.options %}
-            <option value="{{ option.value }}" id="{{ element_options.name ~ "-" ~ option.value }}"
-                    {{ 'selected' if option.selected and not form_data
-                                or form_data is defined and option.value in form_data}}
-                    {{ {'data-absolute_path': absolute_path|tojson|forceescape}|xmlattr }}>
+       {% set option_id = element.id %}
+        {% for option in element.cxd_options %}
+            <option value="{{ option.value }}" id="{{ element.id ~ "-" ~ option.value }}"
+                    {{ 'selected' if option.selected and not element.value
+                                or element.value and option.value in element.value}}
+                    {{ {'data-absolute_path': element.path|tojson|forceescape}|xmlattr }}>
                 {{ option.label }}
             </option>
         {% endfor %}

--- a/questionpy_sdk/webserver/templates/elements/static_text.html.jinja2
+++ b/questionpy_sdk/webserver/templates/elements/static_text.html.jinja2
@@ -1,5 +1,5 @@
 {% extends "elements/element.html.jinja2" %}
 
 {% block content %}
-    <p class="question text">{{ element_options.text }}</p>
+    <p class="question text">{{ element.text }}</p>
 {% endblock %}

--- a/questionpy_sdk/webserver/templates/macros.jinja2
+++ b/questionpy_sdk/webserver/templates/macros.jinja2
@@ -1,80 +1,59 @@
-{% macro create_section(section_name, header, elements, form_data) %}
-    {% set absolute_path = [section_name] %}
+{% macro create_section(section_name, header, elements) %}
     <div class="container elements section" id="{{ section_name }}">
         <h3> {{ header }} </h3>
-        {{ create_elements(section_name, elements, form_data, absolute_path) }}
+        {{ create_elements(elements) }}
     </div>
 {% endmacro %}
 
 
-{% macro create_elements(section_name, element_list, form_data, absolute_path) %}
-    {% for element_options in element_list %}
-        {% set form_data = form_data[element_options.name] if form_data %}
-        {% do absolute_path.append(element_options.name) %}
-        {% set element_id = absolute_path|join("_") %}
-        {% set element_reference = absolute_path|join('][')|replace(']', '', 1) ~ ']' %}
-        {% if element_options.kind == "group" %}
-            {{ create_group(section_name, element_options, form_data, absolute_path) }}
-        {% elif element_options.kind == "repetition" %}
-            {{ create_repetition(section_name, element_options, form_data, absolute_path) }}
+{% macro create_elements(element_list) %}
+    {% for element in element_list %}
+        {% set element_reference = element.path|join('][')|replace(']', '', 1) ~ ']' %}
+        {% if element.kind == "group" %}
+            {{ create_group(element) }}
+        {% elif element.kind == "repetition" %}
+            {{ create_repetition(element) }}
         {% else %}
-            {%  include "elements/" ~ element_options.kind ~ ".html.jinja2" %}
+            {%  include "elements/" ~ element.kind ~ ".html.jinja2" %}
         {% endif %}
-        {% do absolute_path.pop() %}
     {% endfor %}
 {% endmacro %}
 
 
-{% macro create_group(section_name, group_element, form_data, absolute_path) %}
-    <div class="group" id="gr_{{ absolute_path|join("_") }}" name="{{ absolute_path|join('][')|replace(']', '', 1) ~ ']' }}"
-        data-section="{{section_name}}" name="{{ absolute_path|join('][')|replace(']', '', 1) ~ ']' }}"
+{% macro create_group(group_element) %}
+    <div class="group" id="{{ group_element.id }}" name="{{ group_element.path|join('][')|replace(']', '', 1) ~ ']' }}"
+        data-section="{{ group_element.path[0] }}"
         {{ {'data-hide_if': group_element.hide_if|tojson|forceescape}|xmlattr if group_element.hide_if}}
         {{ {'data-disable_if': group_element.disable_if|tojson|forceescape}|xmlattr if group_element.disable_if}}
-        {{ {'data-absolute_path': absolute_path|tojson|forceescape}|xmlattr }}>
+        {{ {'data-absolute_path': group_element.path|tojson|forceescape}|xmlattr }}>
         <h3 class="group-heading">{{ group_element.label }}</h3>
-        {{ create_elements(section_name, group_element.elements, form_data, absolute_path) }}
+        {{ create_elements(group_element.cxd_elements) }}
     </div>
 {% endmacro %}
 
 
-{% macro create_repetition(section_name, repetition_element, form_data, absolute_path) %}
-    {% set element_id = absolute_path|join("_") %}
-    <div class="repetition" id="rep_{{ element_id }}" name="{{ absolute_path|join('][')|replace(']', '', 1) ~ ']' }}"
-         data-section="{{section_name}}">
+{% macro create_repetition(repetition_element) %}
+    <div class="repetition" id="{{ repetition_element.id }}"
+         name="{{ repetition_element.path|join('][')|replace(']', '', 1) ~ ']' }}" data-section="{{ repetition_element.path[0] }}">
 
-        {% if form_data %}
-            {% for repetition in form_data %}
-               {% do absolute_path.append(loop.index) %}
-                <div class="repetition-content" id="">
-                    {{ create_elements(section_name, repetition_element.elements, repetition, absolute_path) }}
-                    <button class="repetition-button-delete" id="rep_{{ element_id }}_delete_button"
-                        name="{{ absolute_path|join('][')|replace(']', '', 1) ~ ']' }}"
-                        {{ {'data-initial_repetitions': repetition_element.initial_repetitions|tojson|forceescape}|xmlattr}}>
-                        Delete
-                    </button>
-                </div>
-                {% do absolute_path.pop() %}
-            {% endfor %}
-        {% else %}
-            {% for n in range(repetition_element.initial_repetitions) %}
-                {% do absolute_path.append(n) %}
-                <div class="repetition-content" id="">
-                    {{ create_elements(section_name, repetition_element.elements, form_data, absolute_path) }}
-                    <button class="repetition-button-delete" id="rep_{{ element_id }}_delete_button"
-                        name="{{ absolute_path|join('][')|replace(']', '', 1) ~ ']' }}"
-                        {{ {'data-initial_repetitions': repetition_element.initial_repetitions|tojson|forceescape}|xmlattr}}>
-                        Delete
-                    </button>
-                </div>
-                {% do absolute_path.pop() %}
-            {% endfor %}
-        {% endif %}
-        <button class="repetition-button" id="rep_{{ element_id }}_button"
-            name="{{ absolute_path|join('][')|replace(']', '', 1) ~ ']' }}"
+        {% for repetition in repetition_element.cxd_elements %}
+            <div class="repetition-content" id="">
+                {{ create_elements(repetition) }}
+                <button class="repetition-button-delete" id="{{ repetition_element.id }}_delete_button"
+                    name="{{ repetition_element.path|join('][')|replace(']', '', 1) ~ ']' }}"
+                    {{ {'data-initial_repetitions': repetition_element.initial_repetitions|tojson|forceescape}|xmlattr}}>
+                    Delete
+                </button>
+            </div>
+        {% endfor %}
+
+        <button class="repetition-button" id="{{ repetition_element.id }}_button"
+            name="{{ repetition_element.path|join('][')|replace(']', '', 1) ~ ']' }}"
             {{ {'data-repetition_increment': repetition_element.increment|tojson|forceescape}|xmlattr
                 if repetition_element.increment}}>
             {{ repetition_element.button_label if repetition_element.button_label else 'Add Repetition' }}
         </button>
+
     </div>
 {% endmacro %}
 

--- a/questionpy_sdk/webserver/templates/options.html.jinja2
+++ b/questionpy_sdk/webserver/templates/options.html.jinja2
@@ -13,9 +13,9 @@
     </div>
 
     <form action="/submit" id="options_form">
-        {{ macros.create_section("general", "General", options.general, form_data) }}
+        {{ macros.create_section("general", "General", options.general) }}
         {% for section in options.sections %}
-            {{ macros.create_section(section.name, section.header, section.elements, form_data) }}
+            {{ macros.create_section(section.name, section.header, section.elements) }}
         {% endfor %}
         <input type="submit" value="Save changes">
         <a hidden="true" id="submit_success_info">Saved!</a>

--- a/tests/webserver/test_context.py
+++ b/tests/webserver/test_context.py
@@ -1,0 +1,79 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
+import pytest
+from questionpy_common.elements import CheckboxElement, FormSection, StaticTextElement, RepetitionElement, \
+    TextInputElement, CheckboxGroupElement, Option, RadioGroupElement, SelectElement, GroupElement
+
+from questionpy.form import is_checked, equals
+from questionpy_sdk.webserver.context import _contextualize_element, _contextualize_element_list, contextualize, \
+    FormElement, CxdFormElement, OptionsFormDefinition, CxdOptionsFormDefinition
+from questionpy_sdk.webserver.elements import CxdStaticTextElement
+
+
+text = TextInputElement()
+static = StaticTextElement()
+checkbox = CheckboxElement()
+checkbox_group = CheckboxGroupElement()
+option = Option()
+radio_group = RadioGroupElement()
+select = SelectElement()
+group = GroupElement()
+repetition = RepetitionElement()
+
+
+
+@pytest.fixture
+def example_form_definition():
+    return OptionsFormDefinition(
+        general=[RepetitionElement(name="my_repetition", initial_repetitions=2, increment=1, elements=[
+            StaticTextElement(name="my_static", label="Static", text="Sample text { qpy:repno }")
+                 ])],
+        sections=[])
+
+
+@pytest.fixture
+def example_form_data(n: int):
+    # Create example form data
+    # Replace this with the appropriate test data for your use case
+    return {"my_repetition": [
+        {"my_static"}
+    ]}
+
+
+# Write tests for _contextualize_element function
+def test_contextualize_element(example_form_definition: OptionsFormDefinition, example_form_data):
+    cxd_options_form = contextualize(example_form_definition, example_form_data)
+    print(cxd_options_form)
+
+
+# Write tests for _contextualize_element_list function
+def test_contextualize_element_list():
+    # Write test cases for _contextualize_element_list function
+    # Test different scenarios and assertions
+    pass
+
+
+# Write tests for contextualize function
+def test_contextualize(example_form_definition, example_form_data):
+    # Test the contextualize function with different scenarios
+    # Ensure expected output and behavior for the given input
+    pass
+
+
+def test_contextualize_static_element():
+    # Create a sample FormElement
+    element = StaticTextElement(name="example", label="Example", text="Sample text")
+
+    # Create a sample form_data
+    form_data = {"example": "example_value"}
+
+    # Call _contextualize_element function
+    cxd_element = _contextualize_element(element, form_data, [], context={"repno": "123"})
+
+    # Assertions based on expected behavior
+    assert isinstance(cxd_element, CxdStaticTextElement)
+    assert cxd_element.label == "Example"
+    # Add more assertions based on the expected behavior
+

--- a/tests/webserver/test_context.py
+++ b/tests/webserver/test_context.py
@@ -41,7 +41,7 @@ def form_elements_fixture(request: SubRequest) -> tuple[FormElement]:
     return request.param
 
 
-@pytest.fixture()
+@pytest.fixture
 def repetition_element_fixture(form_elements_fixture: tuple[FormElement]) -> RepetitionElement:
     return RepetitionElement(name="repetition", initial_repetitions=1, increment=1, elements=form_elements_fixture)
 
@@ -101,7 +101,7 @@ def test_contextualize_should_replace_identifiers(form_definition_fixture: Optio
         assert not _substring_in_cxd_element(element, "qpy:repno")
 
     # the identifier should be replaced with the running number
-    for index, repetition in enumerate(cxd_repetition.cxd_elements):
+    for index, repetition in enumerate(cxd_repetition.cxd_elements, 1):
         for element in repetition:
             assert _substring_in_cxd_element(element, str(index))
 

--- a/tests/webserver/test_context.py
+++ b/tests/webserver/test_context.py
@@ -2,78 +2,116 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
+from itertools import chain
+from typing import Union
+
 import pytest
+from _pytest.fixtures import SubRequest
+
 from questionpy_common.elements import CheckboxElement, FormSection, StaticTextElement, RepetitionElement, \
-    TextInputElement, CheckboxGroupElement, Option, RadioGroupElement, SelectElement, GroupElement
+    TextInputElement, CheckboxGroupElement, Option, RadioGroupElement, SelectElement, GroupElement, \
+    OptionsFormDefinition, FormElement
 
-from questionpy.form import is_checked, equals
-from questionpy_sdk.webserver.context import _contextualize_element, _contextualize_element_list, contextualize, \
-    FormElement, CxdFormElement, OptionsFormDefinition, CxdOptionsFormDefinition
-from questionpy_sdk.webserver.elements import CxdStaticTextElement
+from questionpy_sdk.webserver.context import contextualize, CxdFormElement
+from questionpy_sdk.webserver.elements import CxdRepetitionElement, CxdGroupElement, CxdOption, CxdRadioGroupElement, \
+    CxdSelectElement, CxdCheckboxGroupElement
 
 
-text = TextInputElement()
-static = StaticTextElement()
-checkbox = CheckboxElement()
-checkbox_group = CheckboxGroupElement()
-option = Option()
-radio_group = RadioGroupElement()
-select = SelectElement()
-group = GroupElement()
-repetition = RepetitionElement()
+@pytest.fixture(params=[(
+    TextInputElement(name="text", label="Text", default="Df { qpy:repno }", placeholder="Ph { qpy:repno }"),
+    StaticTextElement(name="static", label="Static", text="Sample text { qpy:repno }"),
+    CheckboxElement(name="chk", left_label="ll { qpy:repno }", right_label="rr { qpy:repno }"),
+    CheckboxGroupElement(name="chk_group", checkboxes=[
+        CheckboxElement(name="chk1", left_label="l1 { qpy:repno }", right_label="r1 { qpy:repno }", ),
+        CheckboxElement(name="chk2", left_label="l2 { qpy:repno }", right_label="r2 { qpy:repno }", )
+    ]),
+    RadioGroupElement(name="radio", label="Text", options=[
+        Option(label="opt1 { qpy:repno }", value="opt1"),
+        Option(label="opt2 { qpy:repno }", value="opt2")
+    ]),
+    SelectElement(name="select", label="Text { qpy:repno }", options=[
+        Option(label="opt1 { qpy:repno }", value="opt1"),
+        Option(label="opt2 { qpy:repno }", value="opt2")
+    ]),
+    GroupElement(name="group", label="Text", elements=[
+        CheckboxElement(name="chk", left_label="ll { qpy:repno }", right_label="rr { qpy:repno }")
+    ])
+)])
+def form_elements_fixture(request: SubRequest) -> tuple[FormElement]:
+    return request.param
 
+
+@pytest.fixture()
+def repetition_element_fixture(form_elements_fixture: tuple[FormElement]) -> RepetitionElement:
+    return RepetitionElement(name="repetition", initial_repetitions=1, increment=1, elements=form_elements_fixture)
 
 
 @pytest.fixture
-def example_form_definition():
+def form_definition_fixture(repetition_element_fixture: RepetitionElement) -> OptionsFormDefinition:
     return OptionsFormDefinition(
-        general=[RepetitionElement(name="my_repetition", initial_repetitions=2, increment=1, elements=[
-            StaticTextElement(name="my_static", label="Static", text="Sample text { qpy:repno }")
-                 ])],
+        general=[repetition_element_fixture],
+        sections=[FormSection(name="section", header="Section", elements=[repetition_element_fixture])])
+
+
+def _substring_in_cxd_element(element: Union[CxdFormElement, CxdOption], substring: str) -> bool:
+    for _, value in element.model_dump().items():
+        if not isinstance(value, str):
+            continue
+        if substring in value:
+            return True
+
+    if isinstance(element, (CxdRadioGroupElement, CxdSelectElement)):
+        return any(_substring_in_cxd_element(opt, substring) for opt in element.cxd_options)
+    if isinstance(element, CxdGroupElement):
+        return any(_substring_in_cxd_element(el, substring) for el in element.cxd_elements)
+    if isinstance(element, CxdCheckboxGroupElement):
+        return any(_substring_in_cxd_element(chk, substring) for chk in element.cxd_checkboxes)
+
+    return False
+
+
+def test_contextualize_should_not_replace_identifier_in_group(form_elements_fixture: tuple[FormElement]) -> None:
+    form_definition = OptionsFormDefinition(
+        general=[RepetitionElement(name="repetition", initial_repetitions=1, increment=1, elements=[
+            GroupElement(name="group { qpy:repno }", label="Text { qpy:repno }", elements=[form_elements_fixture[0]])
+        ])],
         sections=[])
+    cxd_form = contextualize(form_definition, form_data=None)
+
+    cxd_repetition = cxd_form.general[0]
+    assert isinstance(cxd_repetition, CxdRepetitionElement)
+
+    cxd_group = cxd_repetition.cxd_elements[0][0]
+    assert isinstance(cxd_group, CxdGroupElement)
+    assert _substring_in_cxd_element(cxd_group, "qpy:repno")
 
 
-@pytest.fixture
-def example_form_data(n: int):
-    # Create example form data
-    # Replace this with the appropriate test data for your use case
-    return {"my_repetition": [
-        {"my_static"}
-    ]}
+def test_contextualize_should_replace_identifiers(form_definition_fixture: OptionsFormDefinition) -> None:
+    repetition_element = form_definition_fixture.general[0]
+    assert isinstance(repetition_element, RepetitionElement)
+    repetition_element.initial_repetitions = 5
+
+    cxd_form = contextualize(form_definition_fixture, form_data=None)
+    cxd_repetition = cxd_form.general[0]
+    assert isinstance(cxd_repetition, CxdRepetitionElement)
+
+    # the "qpy:repno" identifier should not be in any model fields
+    elements = chain.from_iterable(cxd_repetition.cxd_elements)
+    for element in elements:
+        assert not _substring_in_cxd_element(element, "qpy:repno")
+
+    # the identifier should be replaced with the running number
+    for index, repetition in enumerate(cxd_repetition.cxd_elements):
+        for element in repetition:
+            assert _substring_in_cxd_element(element, str(index))
 
 
-# Write tests for _contextualize_element function
-def test_contextualize_element(example_form_definition: OptionsFormDefinition, example_form_data):
-    cxd_options_form = contextualize(example_form_definition, example_form_data)
-    print(cxd_options_form)
+def test_contextualize_should_not_replace_outside_repetition(form_elements_fixture: tuple[FormElement]) -> None:
+    form_definition = OptionsFormDefinition(
+        general=form_elements_fixture,
+        sections=[])
+    cxd_form = contextualize(form_definition, form_data=None)
 
-
-# Write tests for _contextualize_element_list function
-def test_contextualize_element_list():
-    # Write test cases for _contextualize_element_list function
-    # Test different scenarios and assertions
-    pass
-
-
-# Write tests for contextualize function
-def test_contextualize(example_form_definition, example_form_data):
-    # Test the contextualize function with different scenarios
-    # Ensure expected output and behavior for the given input
-    pass
-
-
-def test_contextualize_static_element():
-    # Create a sample FormElement
-    element = StaticTextElement(name="example", label="Example", text="Sample text")
-
-    # Create a sample form_data
-    form_data = {"example": "example_value"}
-
-    # Call _contextualize_element function
-    cxd_element = _contextualize_element(element, form_data, [], context={"repno": "123"})
-
-    # Assertions based on expected behavior
-    assert isinstance(cxd_element, CxdStaticTextElement)
-    assert cxd_element.label == "Example"
-    # Add more assertions based on the expected behavior
-
+    # the "qpy:repno" identifier should still be in the model fields
+    for element in cxd_form.general:
+        assert _substring_in_cxd_element(element, "qpy:repno")


### PR DESCRIPTION
Siehe [PR 43](https://github.com/questionpy-org/moodle-qtype_questionpy/pull/43)

Außerdem:
- refactoring: Logik wird aus den Jinja2 templates verschoben (besseres Debugging, Fehlervermeidung, Typing, ...)
- Möglichkeit in Zukunft die `contextualize` Methoden zu erweitern.

- ref: [Plugin Issue 38](https://github.com/questionpy-org/moodle-qtype_questionpy/issues/38)