### PR TITLE
Score in der Attempt View anzeigen

### DIFF
--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -101,7 +101,7 @@ async def submit_form(request: web.Request) -> web.Response:
     new_state = question.question_state
     webserver.state_storage.insert(webserver.package_location, json.loads(new_state))
 
-    return web.json_response(new_state)
+    return web.Response(status=201)
 
 
 @routes.post("/repeat")
@@ -140,7 +140,7 @@ async def repeat_element(request: web.Request) -> web.Response:
     return aiohttp_jinja2.render_template("options.html.jinja2", request, context)
 
 
-@routes.get("/attempt")
+@routes.get("/attempt", name="attempt")
 async def get_attempt(request: web.Request) -> web.Response:
     webserver: "WebServer" = request.app["sdk_webserver_app"]
     stored_state = webserver.state_storage.get(webserver.package_location)

--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -12,7 +12,6 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPBadRequest
 from jinja2 import FileSystemLoader
 
-from questionpy_common.api.attempt import ScoringCode
 from questionpy_common.constants import MiB
 from questionpy_common.environment import RequestUser
 from questionpy_sdk.webserver.attempt import get_attempt_scored_context, get_attempt_started_context
@@ -229,9 +228,6 @@ async def submit_attempt(request: web.Request) -> web.Response:
             attempt_state=attempt_state,
             response=last_attempt_data,
         )
-
-    if attempt_scored.scoring_code == ScoringCode.RESPONSE_NOT_SCORABLE:
-        return web.HTTPBadRequest(reason=ScoringCode.RESPONSE_NOT_SCORABLE.value)
 
     response = web.Response(status=201)
     set_cookie(response, "display_options", display_options.model_dump_json())

--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -11,6 +11,7 @@ import aiohttp_jinja2
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPBadRequest
 from jinja2 import FileSystemLoader
+from pydantic import TypeAdapter
 
 from questionpy_common.api.attempt import AttemptScoredModel, ScoreModel
 from questionpy_common.constants import MiB
@@ -222,11 +223,10 @@ async def submit_attempt(request: web.Request) -> web.Response:
             attempt_state=attempt_state,
             response=last_attempt_data,
         )
-    score = ScoreModel.parse_obj(attempt_scored)
 
     response = web.Response(status=201)
     set_cookie(response, "display_options", display_options.model_dump_json())
-    set_cookie(response, "score", score.model_dump_json())
+    set_cookie(response, "score", TypeAdapter(ScoreModel).dump_json(attempt_scored).decode())
     set_cookie(response, "last_attempt_data", json.dumps(last_attempt_data))
     return response
 

--- a/questionpy_sdk/webserver/attempt.py
+++ b/questionpy_sdk/webserver/attempt.py
@@ -2,31 +2,33 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
-from questionpy_common.api.attempt import AttemptUi
+from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel
 from questionpy_sdk.webserver.question_ui import QuestionDisplayOptions, QuestionUIRenderer
 
 
 def get_attempt_started_context(
-    ui: AttemptUi, last_attempt_data: dict, display_options: QuestionDisplayOptions, seed: int
+    attempt: AttemptModel, last_attempt_data: dict, display_options: QuestionDisplayOptions, seed: int
 ) -> dict:
-    renderer = QuestionUIRenderer(xml=ui.content, placeholders=ui.placeholders, seed=seed)
+    renderer = QuestionUIRenderer(xml=attempt.ui.content, placeholders=attempt.ui.placeholders, seed=seed)
     return {
         "question_html": renderer.render_formulation(
             attempt=last_attempt_data, options=QuestionDisplayOptions(general_feedback=False, feedback=False)
         ),
         "options": display_options.model_dump(exclude={"context", "readonly"}),
         "form_disabled": False,
+        "attempt": attempt,
     }
 
 
 def get_attempt_scored_context(
-    ui: AttemptUi, last_attempt_data: dict, display_options: QuestionDisplayOptions, seed: int
+    attempt: AttemptScoredModel, last_attempt_data: dict, display_options: QuestionDisplayOptions, seed: int
 ) -> dict:
-    renderer = QuestionUIRenderer(xml=ui.content, placeholders=ui.placeholders, seed=seed)
+    renderer = QuestionUIRenderer(xml=attempt.ui.content, placeholders=attempt.ui.placeholders, seed=seed)
     context = {
         "question_html": renderer.render_formulation(attempt=last_attempt_data, options=display_options),
         "options": display_options.model_dump(exclude={"context", "readonly"}),
         "form_disabled": True,
+        "attempt": attempt,
     }
 
     if display_options.general_feedback:

--- a/questionpy_sdk/webserver/static/script.js
+++ b/questionpy_sdk/webserver/static/script.js
@@ -249,15 +249,17 @@ async function handle_submit(event) {
     const button = event.currentTarget;
     const form = document.getElementById(button.getAttribute('form'));
     const route = button.getAttribute('data-route');
-    const successAction = form.getAttribute('data-success-action');
+    const successAction = button.getAttribute('data-action');
     const json_form_data = create_json_form_data(form);
     const headers = {'Content-Type': 'application/json'};
     const response = await post_http_request(route, headers, json_form_data);
     if (response.status >= 200 && response.status < 300) {
-        if (successAction === "success-info") {
-            document.getElementById('submit_success_info').hidden = false;
-        } else if (successAction === "reload") {
+        if (successAction === "reload") {
             window.location.reload();
+        } else if (successAction === "redirect") {
+            window.location.href = button.getAttribute('data-redirect');
+        } else if (successAction === "success-info") {
+            document.getElementById('submit_success_info').hidden = false;
         }
     } else {
         alert(response.statusText);

--- a/questionpy_sdk/webserver/static/script.js
+++ b/questionpy_sdk/webserver/static/script.js
@@ -249,7 +249,7 @@ async function handle_submit(event) {
     const button = event.currentTarget;
     const form = document.getElementById(button.getAttribute('form'));
     const route = button.getAttribute('data-route');
-    const successAction = button.getAttribute('data-action');
+    const successAction = button.dataset.action;
     const json_form_data = create_json_form_data(form);
     const headers = {'Content-Type': 'application/json'};
     const response = await post_http_request(route, headers, json_form_data);

--- a/questionpy_sdk/webserver/static/styles.css
+++ b/questionpy_sdk/webserver/static/styles.css
@@ -206,7 +206,12 @@ fieldset {
 	margin-top: 1rem;
 }
 
-#question-display-options table {
+.container-display-options table {
+    padding: 0.1rem 1rem;
+    width: 100%;
+}
+
+.container-question-metainfo table {
     padding: 0.1rem 1rem;
     width: 100%;
 }

--- a/questionpy_sdk/webserver/static/styles.css
+++ b/questionpy_sdk/webserver/static/styles.css
@@ -170,6 +170,19 @@ fieldset {
 
 /* Question Preview Styles */
 
+.container-question-info {
+    float: left;
+    width: 9rem;
+    padding: 0.5rem 1rem;
+    margin-top: 1rem;
+    background-color: #f8f9fa;
+    border-radius: 0.4rem;
+}
+
+.container-question-content {
+    margin: 0 0 2rem 10.5rem;
+}
+
 /* The first child of the question preview is the div containing the question created from the qpy:formulation */
 #question-preview > div {
 	background: rgb(242, 250, 255);

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -8,11 +8,11 @@
 
 {% block content %}
     <div class="container-question-preview">
-        <form id="question-preview" action="/submit" data-success-action="reload">
+        <form id="question-preview" action="/submit">
             {{ question_html|safe }}
         </form>
-        <button id="save-attempt-button" type="submit" data-route="/attempt/save" form="question-preview" {% if form_disabled %}disabled{% endif %}>Save</button>
-        <button id="submit-attempt-button" type="submit" data-route="/attempt" form="question-preview" {% if form_disabled %}disabled{% endif %}>Save and submit</button>
+        <button id="save-attempt-button" type="submit" data-route="/attempt/save" data-action="reload" form="question-preview" {% if form_disabled %}disabled{% endif %}>Save</button>
+        <button id="submit-attempt-button" type="submit" data-route="/attempt" data-action="reload" form="question-preview" {% if form_disabled %}disabled{% endif %}>Save and submit</button>
         <button id="restart-attempt-button" type="button" data-route="/attempt/restart" {% if not form_disabled %}disabled{% endif %}>Restart</button>
         <button id="edit-attempt-button" type="button" data-route="/attempt/edit" {% if not form_disabled %}disabled{% endif %}>Edit</button>
     </div>

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -74,6 +74,24 @@
         </form>
     </div>
 
+    <div class="container-question-metainfo">
+        <h2>Attempt Information</h2>
+        <table>
+            <tbody>
+                <tr>
+                    <td><b>Attempt Class:</b></td>
+                    <td>{{ attempt.__class__ }}</td>
+                </tr>
+                {% for key, value in attempt.dict().items() if key not in ['ui', 'classification'] %}
+                <tr>
+                    <td>{{ key.replace('_', ' ') | capitalize }}:</td>
+                    <td>{{ value }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
     {# TODO: More Preview Settings #}
     {# TODO: Role selection (admin, teacher, student, ...) #}
     {# TODO: Locale selection #}

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -7,37 +7,47 @@
 {% endblock %}
 
 {% block content %}
-    <div class="container-question-preview">
-        <form id="question-preview" action="/submit">
-            {{ question_html|safe }}
-        </form>
+    <div class="container-question-info">
+        <p class="score">
+            {{ ("Score: " ~ attempt.score) if attempt.score or attempt.score == 0 else " Not yet scored" }}
+        </p>
+    </div>
+
+    <div class="container-question-content">
+        <div class="container-question-preview">
+            <form id="question-preview" action="/submit">
+                {{ question_html|safe }}
+            </form>
+        </div>
+
+        {% if general_feedback or specific_feedback or right_answer %}
+            <div class="container-feedback">
+                {% if general_feedback %}
+                    <div class="container-general-feedback">
+                        {{ general_feedback|safe }}
+                    </div>
+                {% endif %}
+
+                {% if specific_feedback %}
+                    <div class="container-specific-feedback">
+                        {{ specific_feedback|safe }}
+                    </div>
+                {% endif %}
+
+                {% if right_answer %}
+                    <div class="container-right-answer">
+                        {{ right_answer|safe }}
+                    </div>
+                {% endif %}
+            </div>
+        {% endif %}
+
         <button id="save-attempt-button" type="submit" data-route="/attempt/save" data-action="reload" form="question-preview" {% if form_disabled %}disabled{% endif %}>Save</button>
         <button id="submit-attempt-button" type="submit" data-route="/attempt" data-action="reload" form="question-preview" {% if form_disabled %}disabled{% endif %}>Save and submit</button>
         <button id="restart-attempt-button" type="button" data-route="/attempt/restart" {% if not form_disabled %}disabled{% endif %}>Restart</button>
         <button id="edit-attempt-button" type="button" data-route="/attempt/edit" {% if not form_disabled %}disabled{% endif %}>Edit</button>
+
     </div>
-
-    {% if general_feedback or specific_feedback or right_answer %}
-        <div class="container-feedback">
-            {% if general_feedback %}
-                <div class="container-general-feedback">
-                    {{ general_feedback|safe }}
-                </div>
-            {% endif %}
-
-            {% if specific_feedback %}
-                <div class="container-specific-feedback">
-                    {{ specific_feedback|safe }}
-                </div>
-            {% endif %}
-
-            {% if right_answer %}
-                <div class="container-right-answer">
-                    {{ right_answer|safe }}
-                </div>
-            {% endif %}
-        </div>
-    {% endif %}
 
     <div class="container-display-options">
         <form id="question-display-options" action="/submit" data-success-action="reload">

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -9,7 +9,7 @@
 {% block content %}
     <div class="container-question-info">
         <p class="score">
-            {{ ("Score: " ~ attempt.score) if attempt.score or attempt.score == 0 else " Not yet scored" }}
+            {{ ("Score: " ~ attempt.score) if attempt.score is defined else "Not yet scored" }}
         </p>
     </div>
 
@@ -42,15 +42,18 @@
             </div>
         {% endif %}
 
-        <button id="save-attempt-button" type="submit" data-route="/attempt/save" data-action="reload" form="question-preview" {% if form_disabled %}disabled{% endif %}>Save</button>
-        <button id="submit-attempt-button" type="submit" data-route="/attempt" data-action="reload" form="question-preview" {% if form_disabled %}disabled{% endif %}>Save and submit</button>
-        <button id="restart-attempt-button" type="button" data-route="/attempt/restart" {% if not form_disabled %}disabled{% endif %}>Restart</button>
-        <button id="edit-attempt-button" type="button" data-route="/attempt/edit" {% if not form_disabled %}disabled{% endif %}>Edit</button>
+        {% set disabled_attribute = "disabled" if form_disabled else "" %}
+        <button id="save-attempt-button" type="submit" data-route="/attempt/save" data-action="reload" form="question-preview" {{ disabled_attribute }}>Save</button>
+        <button id="submit-attempt-button" type="submit" data-route="/attempt" data-action="reload" form="question-preview" {{ disabled_attribute }}>Save and submit</button>
+
+        {% set disabled_attribute = "disabled" if not form_disabled else "" %}
+        <button id="restart-attempt-button" type="button" data-route="/attempt/restart" {{ disabled_attribute }}>Restart</button>
+        <button id="edit-attempt-button" type="button" data-route="/attempt/edit" {{ disabled_attribute }}>Edit</button>
 
     </div>
 
     <div class="container-display-options">
-        <form id="question-display-options" action="/submit" data-success-action="reload">
+        <form id="question-display-options" action="/submit" data-action="reload">
             <h2>Display Options</h2>
             <table>
                 <tbody>

--- a/questionpy_sdk/webserver/templates/options.html.jinja2
+++ b/questionpy_sdk/webserver/templates/options.html.jinja2
@@ -12,12 +12,13 @@
         <p class="manifest-apiversion">API Version: {{ manifest.api_version }}</p>
     </div>
 
-    <form id="options_form" data-success-action="success-info">
+    <form id="options_form">
         {{ macros.create_section("general", "General", options.general) }}
         {% for section in options.sections %}
             {{ macros.create_section(section.name, section.header, section.cxd_elements) }}
         {% endfor %}
         <a hidden="true" id="submit_success_info">Saved!</a>
     </form>
-    <button id="submit-options-button" type="submit" data-route="/submit" form="options_form">Save changes</button>
+    <button id="submit-options-button" type="submit" data-route="/submit" data-action="success-info" form="options_form">Save</button>
+    <button id="submit-and-redirect-options-button" type="submit" data-route="/submit" data-action="redirect" data-redirect="/attempt" form="options_form">Save and display</button>
 {% endblock %}

--- a/questionpy_sdk/webserver/templates/options.html.jinja2
+++ b/questionpy_sdk/webserver/templates/options.html.jinja2
@@ -3,7 +3,7 @@
 
 {% block title %}{{ manifest.short_name }}{%  endblock %}
 {% block header %}
-    <h1>Adding a {{ manifest.short_name }} Question</h1>
+    <h1>{{ manifest.short_name }}</h1>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
**Änderungen**

1. In der Options Form gibt es einen neuen Button `Save and Display` mit dem die Form submittet wird und man zur `/attempt` view weitergeleietet  wird.
  Hier musste ich JS und die Templates refactored 

2. Ähnlich wie bei Moodle werden links in der Question Preview Metadaten zum ScoreModel angezeigt. 
  Bis jetzt ist das nur der `attempt.score` wenn vorhanden.

3. Zusätzliche Informationen zum Attempt werden unter den Display Options angezeigt.