### PR TITLE
test: refactor `click.testing.CliRunner` as a fixture

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -2,7 +2,7 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
-from collections.abc import Generator
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -13,14 +13,14 @@ default_ctx_obj = {"no_interaction": False}
 
 
 @pytest.fixture
-def isolated_runner(monkeypatch: pytest.MonkeyPatch) -> Generator[tuple[CliRunner, Path], Any, Any]:
+def isolated_runner(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[CliRunner, Path]]:
     """Provides Click's `CliRunner` inside an isolated filesystem.
 
     Commands in Click potentially rely on parent context to be available. In a test environment the parent context
     doesn't run and need to be mocked. This fixture provides a default value for `Context.obj` which can be overridden
     on a per-test basis using the `obj` keyword parameter on `CliRunner.invoke`.
 
-    Yields: A named tuple containing the `CliRunner` instance `runner` and the path to the temporary directory `path`.
+    Yields: A tuple containing the `CliRunner` instance `runner` and the path to the temporary directory `path`.
 
     See: https://click.palletsprojects.com/en/8.1.x/api/#click.Context.obj
     """

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,51 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner, Result
+
+default_ctx_obj = {"no_interaction": False}
+
+
+@pytest.fixture
+def isolated_runner(monkeypatch: pytest.MonkeyPatch) -> Generator[tuple[CliRunner, Path], Any, Any]:
+    """Provides Click's `CliRunner` inside an isolated filesystem.
+
+    Commands in Click potentially rely on parent context to be available. In a test environment the parent context
+    doesn't run and need to be mocked. This fixture provides a default value for `Context.obj` which can be overridden
+    on a per-test basis using the `obj` keyword parameter on `CliRunner.invoke`.
+
+    Yields: A named tuple containing the `CliRunner` instance `runner` and the path to the temporary directory `path`.
+
+    See: https://click.palletsprojects.com/en/8.1.x/api/#click.Context.obj
+    """
+    runner = CliRunner()
+    invoke_orig = runner.invoke
+
+    def invoke(*args: Any, **kwargs: Any) -> Result:
+        new_obj = (
+            {**default_ctx_obj, **kwargs["obj"]}
+            if "obj" in kwargs and isinstance(kwargs["obj"], dict)
+            else default_ctx_obj
+        )
+        return invoke_orig(*args, **{"obj": new_obj, **kwargs})
+
+    with monkeypatch.context() as mp:
+        mp.setattr(runner, "invoke", invoke)
+        with runner.isolated_filesystem() as fs:
+            yield runner, Path(fs)
+
+
+@pytest.fixture
+def runner(isolated_runner: tuple[CliRunner, Path]) -> CliRunner:
+    return isolated_runner[0]
+
+
+@pytest.fixture
+def cwd(isolated_runner: tuple[CliRunner, Path]) -> Path:
+    return isolated_runner[1]

--- a/tests/cli/repo/test_structure.py
+++ b/tests/cli/repo/test_structure.py
@@ -9,94 +9,86 @@ from click.testing import CliRunner
 
 from questionpy_sdk.commands._helper import create_normalized_filename
 from questionpy_sdk.commands.repo.structure import structure
-from tests.conftest import assert_same_structure, create_package
+
+from .conftest import assert_same_structure, create_package
 
 
-def test_structure_no_arguments_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(structure)
-        assert result.exit_code != 0
-        assert "Error: Missing argument 'ROOT'." in result.stdout
+def test_structure_no_arguments_raises_error(runner: CliRunner) -> None:
+    result = runner.invoke(structure)
+    assert result.exit_code != 0
+    assert "Error: Missing argument 'ROOT'." in result.stdout
 
 
-def test_structure_with_not_existing_root_path_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(structure, ["root"])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for 'ROOT': Directory 'root' does not exist." in result.stdout
+def test_structure_with_not_existing_root_path_raises_error(runner: CliRunner) -> None:
+    result = runner.invoke(structure, ["root"])
+    assert result.exit_code != 0
+    assert "Error: Invalid value for 'ROOT': Directory 'root' does not exist." in result.stdout
 
 
-def test_structure_with_file_as_root_path_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        Path(directory, "root").touch()
-        result = runner.invoke(structure, ["root"])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for 'ROOT': Directory 'root' is a file." in result.stdout
+def test_structure_with_file_as_root_path_raises_error(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "root").touch()
+
+    result = runner.invoke(structure, ["root"])
+
+    assert result.exit_code != 0
+    assert "Error: Invalid value for 'ROOT': Directory 'root' is a file." in result.stdout
 
 
-def test_structure_with_missing_out_path_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        Path(directory, "root").mkdir()
-        result = runner.invoke(structure, ["root"])
-        assert result.exit_code != 0
-        assert "Error: Missing argument 'OUT_PATH'" in result.stdout
+def test_structure_with_missing_out_path_raises_error(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "root").mkdir()
+
+    result = runner.invoke(structure, ["root"])
+
+    assert result.exit_code != 0
+    assert "Error: Missing argument 'OUT_PATH'" in result.stdout
 
 
-def test_structure_with_existing_out_path_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        Path(directory, "root").mkdir()
-        Path(directory, "out").mkdir()
-        result = runner.invoke(structure, ["root", "out"])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for 'OUT_PATH': Path 'out' is a directory." in result.stdout
+def test_structure_with_existing_out_path_raises_error(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "root").mkdir()
+    (cwd / "out").mkdir()
+
+    result = runner.invoke(structure, ["root", "out"])
+
+    assert result.exit_code != 0
+    assert "Error: Invalid value for 'OUT_PATH': Path 'out' is a directory." in result.stdout
 
 
-def test_structure_with_empty_folder() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        Path(directory, "root").mkdir()
-        result = runner.invoke(structure, ["root", "out"])
-        assert result.exit_code == 0
+def test_structure_with_empty_folder(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "root").mkdir()
+    out_path = cwd / "out"
 
-        out_path = Path(directory, "out")
-        assert out_path.exists()
+    result = runner.invoke(structure, ["root", "out"])
 
-        assert_same_structure(
-            out_path,
-            [
-                out_path / "META.json",
-                out_path / "PACKAGES.json.gz",
-            ],
-        )
+    assert result.exit_code == 0
+    assert out_path.exists()
+    assert_same_structure(
+        out_path,
+        (
+            out_path / "META.json",
+            out_path / "PACKAGES.json.gz",
+        ),
+    )
 
 
 @pytest.mark.parametrize("count", [1, 3])
-def test_structure_creates_only_one_package_if_identical(count: int) -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        root = Path(directory, "root")
-        root.mkdir()
+def test_structure_creates_only_one_package_if_identical(count: int, runner: CliRunner, cwd: Path) -> None:
+    root = cwd / "root"
+    root.mkdir()
+    for i in range(count):
+        _, config = create_package(root / f"{i}.qpy", "package")
+    out = cwd / "out"
 
-        for i in range(count):
-            _, config = create_package(root / f"{i}.qpy", "package")
+    result = runner.invoke(structure, ["root", "out"])
 
-        out = Path(directory, "out")
-        result = runner.invoke(structure, ["root", "out"])
-
-        assert result.exit_code == 0
-        assert_same_structure(
-            Path(directory, "out"),
-            [
-                out / "META.json",
-                out / "PACKAGES.json.gz",
-                out / config.namespace / config.short_name / create_normalized_filename(config),
-            ],
-        )
+    assert result.exit_code == 0
+    assert_same_structure(
+        out,
+        (
+            out / "META.json",
+            out / "PACKAGES.json.gz",
+            out / config.namespace / config.short_name / create_normalized_filename(config),
+        ),
+    )
 
 
 @pytest.mark.parametrize(
@@ -117,28 +109,28 @@ def test_structure_creates_only_one_package_if_identical(count: int) -> None:
         "same_package-different_versions",
     ],
 )
-def test_structure_with_multiple_packages(package_1: tuple[str, str, str], package_2: tuple[str, str, str]) -> None:
+def test_structure_with_multiple_packages(
+    package_1: tuple[str, str, str], package_2: tuple[str, str, str], runner: CliRunner, cwd: Path
+) -> None:
     namespace_1, short_name_1, version_1 = package_1
     namespace_2, short_name_2, version_2 = package_2
 
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        root = Path(directory, "root")
-        root.mkdir()
+    out = cwd / "out"
+    root = cwd / "root"
+    root.mkdir()
 
-        _, config_1 = create_package(root / "a.qpy", short_name_1, namespace=namespace_1, version=version_1)
-        _, config_2 = create_package(root / "b.qpy", short_name_2, namespace=namespace_2, version=version_2)
+    _, config_1 = create_package(root / "a.qpy", short_name_1, namespace=namespace_1, version=version_1)
+    _, config_2 = create_package(root / "b.qpy", short_name_2, namespace=namespace_2, version=version_2)
 
-        out = Path(directory, "out")
-        result = runner.invoke(structure, ["root", "out"])
+    result = runner.invoke(structure, ["root", "out"])
 
-        assert result.exit_code == 0
-        assert_same_structure(
-            Path(directory, "out"),
-            [
-                out / "META.json",
-                out / "PACKAGES.json.gz",
-                out / config_1.namespace / config_1.short_name / create_normalized_filename(config_1),
-                out / config_2.namespace / config_2.short_name / create_normalized_filename(config_2),
-            ],
-        )
+    assert result.exit_code == 0
+    assert_same_structure(
+        out,
+        (
+            out / "META.json",
+            out / "PACKAGES.json.gz",
+            out / config_1.namespace / config_1.short_name / create_normalized_filename(config_1),
+            out / config_2.namespace / config_2.short_name / create_normalized_filename(config_2),
+        ),
+    )

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -26,54 +26,43 @@ def packages_are_equal(directory_1: Path, directory_2: Path) -> bool:
     return True
 
 
-def test_create_no_arguments() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(create)
-        assert result.exit_code != 0
-        assert "Error: Missing argument 'SHORT_NAME'." in result.stdout
+def test_create_no_arguments(runner: CliRunner) -> None:
+    result = runner.invoke(create)
+    assert result.exit_code != 0
+    assert "Error: Missing argument 'SHORT_NAME'." in result.stdout
 
 
-def test_create_example_package() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        with ZipFile(EXAMPLE_PACKAGE) as zip_file:
-            original = directory / "original"
-            original.mkdir()
-            zip_file.extractall(original / "example")
+def test_create_example_package(runner: CliRunner, cwd: Path) -> None:
+    with ZipFile(EXAMPLE_PACKAGE) as zip_file:
+        original = cwd / "original"
+        original.mkdir()
+        zip_file.extractall(original / "example")
 
-        result = runner.invoke(create, ["example"])
-        assert result.exit_code == 0
-        assert (directory / "example").exists()
-        assert packages_are_equal(directory / "example", original / "example")
+    result = runner.invoke(create, ["example"])
+    assert result.exit_code == 0
+    assert (cwd / "example").exists()
+    assert packages_are_equal(cwd / "example", original / "example")
 
 
-def test_create_with_existing_path() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        Path(directory, "short_name").mkdir()
-        result = runner.invoke(create, ["short_name"])
-        assert result.exit_code != 0
-        assert "The path 'short_name' already exists." in result.stdout
+def test_create_with_existing_path(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "short_name").mkdir()
+    result = runner.invoke(create, ["short_name"])
+    assert result.exit_code != 0
+    assert "The path 'short_name' already exists." in result.stdout
 
 
-def test_create_with_out_path() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        out_path = Path(directory, "out")
-        result = runner.invoke(create, ["example", "--out", str(out_path)])
-        assert result.exit_code == 0
-        assert out_path.exists()
+def test_create_with_out_path(runner: CliRunner, cwd: Path) -> None:
+    out_path = cwd / "out"
+    result = runner.invoke(create, ["example", "--out", str(out_path)])
+    assert result.exit_code == 0
+    assert out_path.exists()
 
 
 @pytest.mark.parametrize("short_name", ["default", "a_name", "_name", "name_", "_name_", "_a_name_", "a" * 127])
-def test_create_with_valid_short_name(short_name: str) -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        result = runner.invoke(create, [short_name])
-        assert result.exit_code == 0
-        assert Path(directory, short_name).exists()
+def test_create_with_valid_short_name(short_name: str, runner: CliRunner, cwd: Path) -> None:
+    result = runner.invoke(create, [short_name])
+    assert result.exit_code == 0
+    assert (cwd / short_name).exists()
 
 
 @pytest.mark.parametrize(
@@ -95,21 +84,17 @@ def test_create_with_valid_short_name(short_name: str) -> None:
         "_",
     ],
 )
-def test_create_with_invalid_short_name(short_name: str) -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(create, [short_name])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for 'SHORT_NAME': " in result.stdout
+def test_create_with_invalid_short_name(short_name: str, runner: CliRunner) -> None:
+    result = runner.invoke(create, [short_name])
+    assert result.exit_code != 0
+    assert "Error: Invalid value for 'SHORT_NAME': " in result.stdout
 
 
 @pytest.mark.parametrize("namespace", ["default", "a_name", "_name", "name_", "_name_", "_a_name_", "a" * 127])
-def test_create_with_valid_namespace(namespace: str) -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        result = runner.invoke(create, ["short_name", "--namespace", namespace])
-        assert result.exit_code == 0
-        assert Path(directory, "short_name").exists()
+def test_create_with_valid_namespace(namespace: str, runner: CliRunner, cwd: Path) -> None:
+    result = runner.invoke(create, ["short_name", "--namespace", namespace])
+    assert result.exit_code == 0
+    assert (cwd / "short_name").exists()
 
 
 @pytest.mark.parametrize(
@@ -131,9 +116,7 @@ def test_create_with_valid_namespace(namespace: str) -> None:
         "_",
     ],
 )
-def test_create_with_invalid_namespace(namespace: str) -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(create, ["short_name", "--namespace", namespace])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for '--namespace' / '-n': " in result.stdout
+def test_create_with_invalid_namespace(namespace: str, runner: CliRunner) -> None:
+    result = runner.invoke(create, ["short_name", "--namespace", namespace])
+    assert result.exit_code != 0
+    assert "Error: Invalid value for '--namespace' / '-n': " in result.stdout

--- a/tests/cli/test_package.py
+++ b/tests/cli/test_package.py
@@ -28,187 +28,139 @@ def create_config(source: Path) -> PackageConfig:
 def create_source_directory(root: Path, directory_name: str) -> PackageConfig:
     """Creates a source directory with a config in the given `root` directory."""
     source = root / directory_name
-    source.mkdir()
+    source_python = source / "python" / "local" / "short_name"
+    source_python.mkdir(parents=True)
+    (source_python / "__init__.py").touch()
     return create_config(source)
 
 
-def test_package_with_example_package() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        with ZipFile(EXAMPLE_PACKAGE) as zip_file:
-            zip_file.extractall(directory)
-        result = runner.invoke(package, [directory])
-        assert result.exit_code == 0
-        assert "Successfully created " in result.stdout
+def test_package_with_example_package(runner: CliRunner, cwd: Path) -> None:
+    with ZipFile(EXAMPLE_PACKAGE) as zip_file:
+        zip_file.extractall(cwd)
+
+    result = runner.invoke(package, [str(cwd)])
+
+    assert result.exit_code == 0
+    assert "Successfully created " in result.stdout
 
 
-def test_package_no_arguments_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(package)
-        assert result.exit_code != 0
-        assert "Error: Missing argument 'SOURCE'." in result.stdout
+def test_package_no_arguments_raises_error(runner: CliRunner) -> None:
+    result = runner.invoke(package)
+
+    assert result.exit_code != 0
+    assert "Error: Missing argument 'SOURCE'." in result.stdout
 
 
-def test_package_with_not_existing_source_path_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(package, ["source"])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for 'SOURCE': Directory 'source' does not exist." in result.stdout
+def test_package_with_not_existing_source_path_raises_error(runner: CliRunner) -> None:
+    result = runner.invoke(package, ["source"])
+
+    assert result.exit_code != 0
+    assert "Error: Invalid value for 'SOURCE': Directory 'source' does not exist." in result.stdout
 
 
-def test_package_with_file_as_source_path_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        Path(directory, "source").touch()
-        result = runner.invoke(package, ["source"])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for 'SOURCE': Directory 'source' is a file." in result.stdout
+def test_package_with_file_as_source_path_raises_error(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "source").touch()
+
+    result = runner.invoke(package, ["source"])
+
+    assert result.exit_code != 0
+    assert "Error: Invalid value for 'SOURCE': Directory 'source' is a file." in result.stdout
 
 
-def test_package_with_missing_config_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        Path(directory, "source").mkdir()
-        result = runner.invoke(package, ["source"])
-        assert result.exit_code != 0
-        assert f"Error: The config 'source/{PACKAGE_CONFIG_FILENAME}' does not exist." in result.stdout
+def test_package_with_missing_config_raises_error(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "source").mkdir()
+
+    result = runner.invoke(package, ["source"])
+
+    assert result.exit_code != 0
+    assert f"Error: The config 'source/{PACKAGE_CONFIG_FILENAME}' does not exist." in result.stdout
 
 
-def test_package_with_invalid_out_path_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as directory:
-        Path(directory, "source").mkdir()
-        result = runner.invoke(package, ["source", "--out", "out"])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for '--out' / '-o': Packages need the extension '.qpy'." in result.stdout
+def test_package_with_invalid_out_path_raises_error(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "source").mkdir()
+
+    result = runner.invoke(package, ["source", "--out", "out"])
+
+    assert result.exit_code != 0
+    assert "Error: Invalid value for '--out' / '-o': Packages need the extension '.qpy'." in result.stdout
 
 
-def test_package_with_only_source() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        config = create_source_directory(Path(fs), "source")
-        result = runner.invoke(package, ["source"])
-        assert result.exit_code == 0
-        assert Path(".", f"{create_normalized_filename(config)}").exists()
+def test_package_with_only_source(runner: CliRunner, cwd: Path) -> None:
+    config = create_source_directory(cwd, "source")
+
+    result = runner.invoke(package, ["source"])
+
+    assert result.exit_code == 0
+    assert Path(".", f"{create_normalized_filename(config)}").exists()
 
 
-def test_package_creates_package_in_cwd() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        config = create_source_directory(directory, "source")
+def test_package_creates_package_in_cwd(runner: CliRunner, cwd: Path) -> None:
+    config = create_source_directory(cwd, "source")
+    # Change current working directory to 'cwd'.
+    cwd = cwd / "cwd"
+    cwd.mkdir()
+    os.chdir(cwd)
 
-        # Change current working directory to 'cwd'.
-        cwd = Path(directory, "cwd")
-        cwd.mkdir()
-        os.chdir(cwd)
+    result = runner.invoke(package, ["../source"])
 
-        result = runner.invoke(package, ["../source"])
-        assert result.exit_code == 0
-        assert Path(".", create_normalized_filename(config)).exists()
+    assert result.exit_code == 0
+    assert Path(".", create_normalized_filename(config)).exists()
 
 
-def test_package_with_out_path() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        create_source_directory(directory, "source")
+def test_package_with_out_path(runner: CliRunner, cwd: Path) -> None:
+    create_source_directory(cwd, "source")
 
-        result = runner.invoke(package, ["source", "--out", "source.qpy"])
-        assert result.exit_code == 0
-        assert Path(directory, "source.qpy").exists()
+    result = runner.invoke(package, ["source", "--out", "source.qpy"])
+
+    assert result.exit_code == 0
+    assert (cwd / "source.qpy").exists()
 
 
-def test_package_with_not_existing_config_as_argument_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        (directory / "config").mkdir()
-        result = runner.invoke(package, ["source", "--config", "config.yml"])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for '--config' / '-c': File 'config.yml' does not exist." in result.stdout
+def test_package_with_not_existing_config_raises_error(runner: CliRunner, cwd: Path) -> None:
+    create_source_directory(cwd, "source")
+    (cwd / "source" / PACKAGE_CONFIG_FILENAME).unlink()
 
+    result = runner.invoke(package, ["source"])
 
-def test_package_with_directory_as_config_argument_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        (directory / "source").mkdir()
-        (directory / "config.yml").mkdir()
-        result = runner.invoke(package, ["source", "--config", "config.yml"])
-        assert result.exit_code != 0
-        assert "Error: Invalid value for '--config' / '-c': File 'config.yml' is a directory." in result.stdout
-
-
-def test_package_with_invalid_yaml_as_config_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        (directory / "source").mkdir()
-        (directory / "config.yml").write_text("{")
-
-        result = runner.invoke(package, ["source", "--config", "config.yml"])
-        assert result.exit_code != 0
-        assert "Error: Failed to parse config 'config.yml': " in result.stdout
-
-
-def test_package_with_invalid_config_raises_error() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        (directory / "source").mkdir()
-        (directory / "config.yml").write_text("invalid: config")
-
-        result = runner.invoke(package, ["source", "--config", "config.yml"])
-        assert result.exit_code != 0
-        assert "Invalid config 'config.yml': " in result.stdout
-
-
-def test_package_with_namespace_argument() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-
-        # Create empty source directory and config in the root directory.
-        (directory / "source").mkdir()
-        config = create_config(directory)
-
-        result = runner.invoke(package, ["source", "--config", PACKAGE_CONFIG_FILENAME])
-        assert f"Successfully created '{create_normalized_filename(config)}'." in result.stdout
-        assert result.exit_code == 0
+    assert result.exit_code != 0
+    assert f"Error: The config 'source/{PACKAGE_CONFIG_FILENAME}' does not exist." in result.stdout
 
 
 @pytest.mark.parametrize("prompt_input", ["n", "N", "\n", "not_y"])
-def test_package_with_existing_file_and_not_overwriting(prompt_input: str) -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        create_source_directory(directory, "source")
-        (directory / "source.qpy").touch()
+def test_package_with_existing_file_and_not_overwriting(prompt_input: str, runner: CliRunner, cwd: Path) -> None:
+    create_source_directory(cwd, "source")
+    (cwd / "source.qpy").touch()
 
-        result = runner.invoke(package, ["source", "--out", "source.qpy"], input=prompt_input)
-        assert "The path 'source.qpy' already exists. Do you want to overwrite it?" in result.stdout
-        assert "Aborted!" in result.stdout
-        assert result.exit_code != 0
+    result = runner.invoke(package, ["source", "--out", "source.qpy"], input=prompt_input)
+
+    assert "The path 'source.qpy' already exists. Do you want to overwrite it?" in result.stdout
+    assert "Aborted!" in result.stdout
+    assert result.exit_code != 0
 
 
 @pytest.mark.parametrize("prompt_input", ["y", "Y"])
-def test_package_with_existing_file_and_overwriting(prompt_input: str) -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        directory = Path(fs)
-        create_source_directory(directory, "source")
-        (directory / "source.qpy").touch()
+def test_package_with_existing_file_and_overwriting(prompt_input: str, runner: CliRunner, cwd: Path) -> None:
+    create_source_directory(cwd, "source")
+    (cwd / "source.qpy").touch()
 
-        result = runner.invoke(package, ["source", "--out", "source.qpy"], input=prompt_input)
-        assert "The path 'source.qpy' already exists. Do you want to overwrite it?" in result.stdout
-        assert "Successfully created 'source.qpy'." in result.stdout
-        assert result.exit_code == 0
+    result = runner.invoke(package, ["source", "--out", "source.qpy"], input=prompt_input)
+
+    assert "The path 'source.qpy' already exists. Do you want to overwrite it?" in result.stdout
+    assert "Successfully created 'source.qpy'." in result.stdout
+    assert result.exit_code == 0
 
 
 # TODO: Implement or remove this test
 @pytest.mark.skip(reason="Not implemented yet.")
 def test_installing_requirement_fails() -> None:
+    pass
+
+
+@pytest.mark.skip(reason="Not implemented yet.")
+def test_no_interaction() -> None:
+    pass
+
+
+@pytest.mark.skip(reason="Not implemented yet.")
+def test_force_overwrite() -> None:
     pass

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -2,7 +2,6 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
-import os
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -11,35 +10,28 @@ from questionpy_sdk.commands.run import run
 from questionpy_sdk.constants import PACKAGE_CONFIG_FILENAME
 
 
-def test_run_no_arguments() -> None:
-    runner = CliRunner()
+def test_run_no_arguments(runner: CliRunner) -> None:
     result = runner.invoke(run)
     assert result.exit_code != 0
     assert "Error: Missing argument 'PACKAGE'." in result.stdout
 
 
-def test_run_with_not_existing_package() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(run, ["package.qpy"])
-        assert result.exit_code != 0
-        assert "'package.qpy' doesn't look like a QPy package zip file, directory or module" in result.stdout
+def test_run_with_not_existing_package(runner: CliRunner) -> None:
+    result = runner.invoke(run, ["package.qpy"])
+    assert result.exit_code != 0
+    assert "'package.qpy' doesn't look like a QPy package zip file, directory or module" in result.stdout
 
 
-def test_run_non_zip_file() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        with open(Path(fs) / "README.md", "w", encoding="utf-8") as f:
-            f.write("Foo bar")
-        result = runner.invoke(run, ["README.md"])
-        assert result.exit_code != 0
-        assert "'README.md' doesn't look like a QPy package zip file, directory or module" in result.stdout
+def test_run_non_zip_file(runner: CliRunner, cwd: Path) -> None:
+    with open(cwd / "README.md", "w", encoding="utf-8") as f:
+        f.write("Foo bar")
+    result = runner.invoke(run, ["README.md"])
+    assert result.exit_code != 0
+    assert "'README.md' doesn't look like a QPy package zip file, directory or module" in result.stdout
 
 
-def test_run_dir_without_config() -> None:
-    runner = CliRunner()
-    with runner.isolated_filesystem() as fs:
-        os.mkdir(Path(fs) / "tests")
-        result = runner.invoke(run, ["tests"])
-        assert result.exit_code != 0
-        assert f"The config 'tests/{PACKAGE_CONFIG_FILENAME}' does not exist" in result.stdout
+def test_run_dir_without_config(runner: CliRunner, cwd: Path) -> None:
+    (cwd / "tests").mkdir()
+    result = runner.invoke(run, ["tests"])
+    assert result.exit_code != 0
+    assert f"The config 'tests/{PACKAGE_CONFIG_FILENAME}' does not exist" in result.stdout


### PR DESCRIPTION
Der PR fügt pytest fixtures hinzu, welche den `click.testing.CliRunner` kapseln: `runner`, `cwd`. Dadurch werden die Tests etwas übersichtlicher und schmaler.

Aber der eigentliche Grund für den PR war, dass Commands beim `CliRunner` in Isolation laufen und daher der Parent-Kontext nie ausgeführt wird (`questionpy_sdk.__main__.cli`). Das war bisher kein Problem, da eh kein Command auf den Kontext zugegriffen hat. `isolated_runner` mockt den Parent-Context, lässt sich bei Bedarf aber auch direkt im Test überschreiben.

@janbritz Zwei Sachen, die mir aufgefallen sind:

1. Kleinigkeit: `test_index_allows_packages_in_subdirectories` war fehlerhaft. Sollte eigentlich n Unterverzeichnisse erstellen, hat aber n mal dasselbe Verzeichnis erstellt.  
2. `conftest.create_package` war mir irgendwie nicht klar. Das skippt/xfailt tests ("The test will skip if the packaging fails and xfail if the config is invalid." steht im docstring). Das führte dann dazu, dass tests teilweise geskippt/xfailt sind, ohne dass ich es gemerkt habe. Ich denke diese Tests sollten failen, wenn Pakete nicht gebaut werden können. Oder entgeht mir hier etwas?