### PR TITLE
Extra state fields / Webserver UI Änderungen

### DIFF
--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -193,6 +193,7 @@ async def get_attempt(request: web.Request) -> web.Response:
 
     context = get_attempt_render_context(
         attempt,
+        attempt_state,
         last_attempt_data=last_attempt_data,
         display_options=display_options,
         seed=seed,

--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -254,9 +254,10 @@ async def submit_display_options(request: web.Request) -> web.Response:
 async def restart_attempt(request: web.Request) -> web.Response:
     """Restarts the attempt by deleting the attempt scored state and last attempt data and by resetting the seed."""
     response = web.Response(status=201)
+    response.del_cookie("attempt_state")
     response.del_cookie("score")
     response.del_cookie("last_attempt_data")
-    set_cookie(response, "attempt_seed", str(random.randint(0, 10)))
+    response.del_cookie("attempt_seed")
     return response
 
 

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -46,8 +46,9 @@
         <button id="save-attempt-button" type="submit" data-route="/attempt/save" data-action="reload" form="question-preview" {{ disabled_attribute }}>Save</button>
         <button id="submit-attempt-button" type="submit" data-route="/attempt" data-action="reload" form="question-preview" {{ disabled_attribute }}>Save and submit</button>
 
+        <button id="restart-attempt-button" type="button" data-route="/attempt/restart">Restart</button>
+
         {% set disabled_attribute = "disabled" if not form_disabled else "" %}
-        <button id="restart-attempt-button" type="button" data-route="/attempt/restart" {{ disabled_attribute }}>Restart</button>
         <button id="edit-attempt-button" type="button" data-route="/attempt/edit" {{ disabled_attribute }}>Edit</button>
 
     </div>

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -85,15 +85,32 @@
         <table>
             <tbody>
                 <tr>
-                    <td><b>Attempt Class:</b></td>
-                    <td>{{ attempt.__class__ }}</td>
+                    <td>Attempt status:</td>
+                    <td><b>{{ attempt_status }}</b></td>
                 </tr>
-                {% for key, value in attempt.dict().items() if key not in ['ui', 'classification'] %}
                 <tr>
-                    <td>{{ key.replace('_', ' ') | capitalize }}:</td>
-                    <td>{{ value }}</td>
+                    <td>Variant:</td>
+                    <td>{{ attempt.variant }}</td>
                 </tr>
-                {% endfor %}
+                <tr>
+                    <td>Attempt state:</td>
+                    <td>{{ attempt_state }}</td>
+                </tr>
+
+                {% if attempt.scoring_code is defined %}
+                    <tr>
+                        <td>Scoring code:</td>
+                        <td>{{ attempt.scoring_code }}</td>
+                    </tr>
+                    <tr>
+                        <td>Score (fraction):</td>
+                        <td>{{ attempt.score }}</td>
+                    </tr>
+                    <tr>
+                        <td>Scoring state:</td>
+                        <td>{{ attempt.scoring_state }}</td>
+                    </tr>
+                {% endif %}
             </tbody>
         </table>
     </div>

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -51,6 +51,8 @@
         {% set disabled_attribute = "disabled" if not form_disabled else "" %}
         <button id="edit-attempt-button" type="button" data-route="/attempt/edit" {{ disabled_attribute }}>Edit</button>
 
+        {% set disabled_attribute = "disabled" if attempt.score is undefined else "" %}
+        <button id="rescore-attempt-button" type="submit" data-route="/attempt/rescore" data-action="reload" form="question-preview" {{ disabled_attribute }}>Re-Score</button>
     </div>
 
     <div class="container-display-options">

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -41,11 +41,11 @@ def isolated_runner(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[CliRunner
             yield runner, Path(fs)
 
 
-@pytest.fixture
+@pytest.fixture  # noqa: FURB118
 def runner(isolated_runner: tuple[CliRunner, Path]) -> CliRunner:
     return isolated_runner[0]
 
 
-@pytest.fixture
+@pytest.fixture  # noqa: FURB118
 def cwd(isolated_runner: tuple[CliRunner, Path]) -> Path:
     return isolated_runner[1]

--- a/tests/cli/repo/test_index.py
+++ b/tests/cli/repo/test_index.py
@@ -60,7 +60,7 @@ def test_index_allows_packages_in_subdirectories(depth: int, runner: CliRunner, 
     # Create subdirectories.
     directory = cwd
     for _ in range(depth):
-        directory = directory / "subdirectory"
+        directory /= "subdirectory"
     directory.mkdir(parents=True)
 
     path, _ = create_package(directory, "test")

--- a/tests/cli/test_package.py
+++ b/tests/cli/test_package.py
@@ -97,7 +97,7 @@ def test_package_with_only_source(runner: CliRunner, cwd: Path) -> None:
 def test_package_creates_package_in_cwd(runner: CliRunner, cwd: Path) -> None:
     config = create_source_directory(cwd, "source")
     # Change current working directory to 'cwd'.
-    cwd = cwd / "cwd"
+    cwd /= "cwd"
     cwd.mkdir()
     os.chdir(cwd)
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -23,8 +23,7 @@ def test_run_with_not_existing_package(runner: CliRunner) -> None:
 
 
 def test_run_non_zip_file(runner: CliRunner, cwd: Path) -> None:
-    with open(cwd / "README.md", "w", encoding="utf-8") as f:
-        f.write("Foo bar")
+    (cwd / "README.md").write_text("Foo bar")
     result = runner.invoke(run, ["README.md"])
     assert result.exit_code != 0
     assert "'README.md' doesn't look like a QPy package zip file, directory or module" in result.stdout


### PR DESCRIPTION
Ein paar kleinere Änderungen:
* ~~Setzt `ConfigDict(extra="allow")` in den base states. Das erlaubt zum Beispiel folgendes:~~
  ```python
      def start_attempt(self, variant: int) -> Attempt:
        attempt = super().start_attempt(variant)
        attempt.attempt_state.custom_field = "something"
        return attempt
  ```
  ~~Ohne, dass eine eigene State-Klasse definiert werden muss. Mypy meckert dann zwar, aber Devs, die typsicher unterwegs sein wollen, müssen eben weiterhin eigene Klassen definieren.~~
* Der Restart-Knopf im Webserver startet jetzt tatsächlich den Attempt neu.
* Ich habe einen "Rescore"-Knopf hinzugefügt, damit man [sowas](https://github.com/questionpy-org/questionpy-sdk/compare/demo/required-state-fields?expand=1#diff-aeeb1da8ef6feb585f509b1299385235c14180979b8d0f37fc4b6a9bb0fc92d0R30) testen kann
* Der attempt state wird jetzt immer angezeigt, nicht nur beim neu gestarteten Attempt
* Korrigiert einige Ruff-Meldungen von dev