### PR TITLE
Export to HTML instead of XML to force full HTML compatibility

### DIFF
--- a/questionpy_sdk/webserver/question_ui.py
+++ b/questionpy_sdk/webserver/question_ui.py
@@ -166,7 +166,7 @@ class QuestionUIRenderer:
         # TODO: mangle_ids_and_names
         self.clean_up(newdoc, xpath)
 
-        return etree.tostring(newdoc, pretty_print=True).decode()
+        return etree.tostring(newdoc, pretty_print=True, method="html").decode()
 
     def resolve_placeholders(self, xpath: etree.XPathDocumentEvaluator) -> None:
         """Replace placeholder PIs such as `<?p my_key plain?>` with the appropriate value from `self.placeholders`.
@@ -210,7 +210,7 @@ class QuestionUIRenderer:
                 if cleaned_value.text:
                     content += cleaned_value.text
                 for child in cleaned_value:
-                    content += etree.tostring(child, encoding="unicode", with_tail=True)
+                    content += etree.tostring(child, encoding="unicode", method="html", with_tail=True)
                 replacement = content
             else:
                 replacement = raw_value


### PR DESCRIPTION
Currently, empty tags will be turned into self-closing tags (`<.../>`). However, in HTML, this is only supported for _some_ tags, see https://html.spec.whatwg.org/multipage/syntax.html#start-tags point 6 (void and foreign elements). In some cases this may lead to invalid HTML which doesn't meet expected behavior. This example:
```html
<textarea placeholder="Some placeholder" name="somename" required=""></textarea>
```
will be read from the template, and in the end be rendered as
```html
<textarea placeholder="Some placeholder" name="somename" required=""/>
```
as XML supports self-closing tags in general, and therefore all empty tags will be converted.

**Note** that the change in `questionpy_sdk/webserver/question_ui.py:213` has not been tested.