### PR TITLE
Neue Route zum Abrufen statischer Dateien

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -320,13 +320,13 @@ toml = ["tomli"]
 
 [[package]]
 name = "faker"
-version = "25.4.0"
+version = "25.8.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Faker-25.4.0-py3-none-any.whl", hash = "sha256:c6c2a937c59f12ee9878434c6ad3d6eca5d429d50a9b7c5923d99aa1a7ba5fba"},
-    {file = "Faker-25.4.0.tar.gz", hash = "sha256:2baf32ca8a9e6870445f2248c99b210e5d0e5eadaba5936b407f6eb9d63cb96a"},
+    {file = "Faker-25.8.0-py3-none-any.whl", hash = "sha256:4c40b34a9c569018d4f9d6366d71a4da8a883d5ddf2b23197be5370f29b7e1b6"},
+    {file = "Faker-25.8.0.tar.gz", hash = "sha256:bdec5f2fb057d244ebef6e0ed318fea4dcbdf32c3a1a010766fc45f5d68fc68d"},
 ]
 
 [package.dependencies]
@@ -811,13 +811,13 @@ attrs = ">=19.2.0"
 
 [[package]]
 name = "packaging"
-version = "24.0"
+version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
-    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
 
 [[package]]
@@ -1010,13 +1010,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.3.0"
+version = "2.3.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_settings-2.3.0-py3-none-any.whl", hash = "sha256:26eeed27370a9c5e3f64e4a7d6602573cbedf05ed940f1d5b11c3f178427af7a"},
-    {file = "pydantic_settings-2.3.0.tar.gz", hash = "sha256:78db28855a71503cfe47f39500a1dece523c640afd5280edb5c5c9c9cfa534c9"},
+    {file = "pydantic_settings-2.3.2-py3-none-any.whl", hash = "sha256:ae06e44349e4c7bff8d57aff415dfd397ae75c217a098d54e9e6990ad7594ac7"},
+    {file = "pydantic_settings-2.3.2.tar.gz", hash = "sha256:05d33003c74c2cd585de97b59eb17b6ed67181bc8a3ce594d74b5d24e4df7323"},
 ]
 
 [package.dependencies]
@@ -1041,13 +1041,13 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.2.1"
+version = "8.2.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.2.1-py3-none-any.whl", hash = "sha256:faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1"},
-    {file = "pytest-8.2.1.tar.gz", hash = "sha256:5046e5b46d8e4cac199c373041f26be56fdb81eb4e67dc11d4e10811fc3408fd"},
+    {file = "pytest-8.2.2-py3-none-any.whl", hash = "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343"},
+    {file = "pytest-8.2.2.tar.gz", hash = "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"},
 ]
 
 [package.dependencies]
@@ -1163,6 +1163,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1199,7 +1200,7 @@ files = [
 
 [[package]]
 name = "questionpy-server"
-version = "0.2.4"
+version = "0.2.5"
 description = "QuestionPy application server"
 optional = false
 python-versions = "^3.11"
@@ -1219,8 +1220,8 @@ watchdog = "^4.0.0"
 [package.source]
 type = "git"
 url = "https://github.com/questionpy-org/questionpy-server.git"
-reference = "a50b6b33229f22368f85e7af6d4a79f71814f81b"
-resolved_reference = "a50b6b33229f22368f85e7af6d4a79f71814f81b"
+reference = "763c15bcf3906ebb80d8d0bd9c15e842de4f8b0c"
+resolved_reference = "763c15bcf3906ebb80d8d0bd9c15e842de4f8b0c"
 
 [[package]]
 name = "ruff"
@@ -1357,13 +1358,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.1"
+version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.12.1-py3-none-any.whl", hash = "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a"},
-    {file = "typing_extensions-4.12.1.tar.gz", hash = "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"},
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
@@ -1550,4 +1551,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "cbcef32b50b31e231df36466ef9f5356084f7a1a3b096b72f5e6eac6324484b7"
+content-hash = "f1da0050fb6b89dc4e61b25719cf0363b1a7e8052c8c8322732bdb2f5f8046d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Library and toolset for the development of QuestionPy packages"
 authors = ["innoCampus <info@isis.tu-berlin.de>"]
 license = "MIT"
 homepage = "https://questionpy.org"
-version = "0.2.4"
+version = "0.2.5"
 packages = [
     { include = "questionpy" },
     { include = "questionpy_sdk" }
@@ -28,7 +28,7 @@ python = "^3.11"
 aiohttp = "^3.9.3"
 pydantic = "^2.6.4"
 PyYAML = "^6.0.1"
-questionpy-server = { git = "https://github.com/questionpy-org/questionpy-server.git", rev = "a50b6b33229f22368f85e7af6d4a79f71814f81b" }
+questionpy-server = { git = "https://github.com/questionpy-org/questionpy-server.git", rev = "763c15bcf3906ebb80d8d0bd9c15e842de4f8b0c" }
 jinja2 = "^3.1.3"
 aiohttp-jinja2 = "^1.6"
 lxml = "~5.1.0"

--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -51,6 +51,7 @@ class WebServer:
         # We import here, so we don't have to work around circular imports.
         from questionpy_sdk.webserver.routes.attempt import routes as attempt_routes  # noqa: PLC0415
         from questionpy_sdk.webserver.routes.options import routes as options_routes  # noqa: PLC0415
+        from questionpy_sdk.webserver.routes.worker import routes as worker_routes  # noqa: PLC0415
 
         self.package_location = package_location
         self._state_storage_path = state_storage_path
@@ -60,6 +61,7 @@ class WebServer:
 
         self.web_app.add_routes(attempt_routes)
         self.web_app.add_routes(options_routes)
+        self.web_app.add_routes(worker_routes)
         self.web_app.router.add_static("/static", Path(__file__).parent / "static")
 
         self.web_app.on_startup.append(_extract_manifest)

--- a/questionpy_sdk/webserver/routes/worker.py
+++ b/questionpy_sdk/webserver/routes/worker.py
@@ -1,0 +1,35 @@
+#  This file is part of the QuestionPy SDK. (https://questionpy.org)
+#  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+#  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+from questionpy_sdk.webserver.app import SDK_WEBSERVER_APP_KEY
+
+if TYPE_CHECKING:
+    from questionpy_server.worker.worker import Worker
+
+routes = web.RouteTableDef()
+
+
+@routes.get("/worker/{namespace}/{short_name}/file/{path:(static|static-private)/.*}")
+async def get_static_file(request: web.Request) -> web.Response:
+    webserver = request.app[SDK_WEBSERVER_APP_KEY]
+    namespace = request.match_info["namespace"]
+    short_name = request.match_info["short_name"]
+    path = request.match_info["path"]
+
+    worker: Worker
+    async with webserver.worker_pool.get_worker(webserver.package_location, 0, None) as worker:
+        manifest = await worker.get_manifest()
+        if manifest.namespace != namespace or manifest.short_name != short_name:
+            return web.HTTPNotFound(reason="Package not found.")
+
+        try:
+            file = await worker.get_static_file(path)
+        except FileNotFoundError:
+            return web.HTTPNotFound(reason="File not found.")
+
+    return web.Response(body=file.data, content_type=file.mime_type, headers={"Cache-Control": "no-cache"})


### PR DESCRIPTION
Die URL enthält nicht den Paket-Hash, da dieser nicht immer bekannt ist (wenn ein Ordner direkt ausgeführt wird). Dafür wird ein no-cache Header übermittelt (der Paket-Hash hätte sonst für das Cache-busting gesorgt).

Closes #87