### PR TITLE
refactor: remove unnecessary `worker` variable declaration

### DIFF
--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -4,7 +4,6 @@
 import traceback
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import aiohttp_jinja2
 from aiohttp import web
@@ -18,13 +17,9 @@ from questionpy_server import WorkerPool
 from questionpy_server.worker.runtime.package_location import PackageLocation
 from questionpy_server.worker.worker.thread import ThreadWorker
 
-if TYPE_CHECKING:
-    from questionpy_server.worker.worker import Worker
-
 
 async def _extract_manifest(app: web.Application) -> None:
     webserver = app[SDK_WEBSERVER_APP_KEY]
-    worker: Worker
     async with webserver.worker_pool.get_worker(webserver.package_location, 0, None) as worker:
         app[MANIFEST_APP_KEY] = await worker.get_manifest()
 

--- a/questionpy_sdk/webserver/routes/attempt.py
+++ b/questionpy_sdk/webserver/routes/attempt.py
@@ -4,7 +4,6 @@
 
 import json
 import random
-from typing import TYPE_CHECKING
 
 import aiohttp_jinja2
 from aiohttp import web
@@ -15,9 +14,6 @@ from questionpy_common.environment import RequestUser
 from questionpy_sdk.webserver.app import SDK_WEBSERVER_APP_KEY
 from questionpy_sdk.webserver.attempt import get_attempt_render_context
 from questionpy_sdk.webserver.question_ui import QuestionDisplayOptions
-
-if TYPE_CHECKING:
-    from questionpy_server.worker.worker import Worker
 
 routes = web.RouteTableDef()
 
@@ -48,7 +44,6 @@ async def get_attempt(request: web.Request) -> web.Response:
     if score_json:
         score = ScoreModel.model_validate_json(score_json)
 
-    worker: Worker
     if attempt_state:
         # Display a previously started attempt.
         async with webserver.worker_pool.get_worker(webserver.package_location, 0, None) as worker:
@@ -108,7 +103,6 @@ async def _score_attempt(request: web.Request, data: dict) -> web.Response:
     score_json = request.cookies.get("score")
     score = ScoreModel.model_validate_json(score_json) if score_json else None
 
-    worker: Worker
     async with webserver.worker_pool.get_worker(webserver.package_location, 0, None) as worker:
         attempt_scored = await worker.score_attempt(
             request_user=RequestUser(["de", "en"]),

--- a/questionpy_sdk/webserver/routes/options.py
+++ b/questionpy_sdk/webserver/routes/options.py
@@ -2,7 +2,7 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
-from typing import TYPE_CHECKING, Never
+from typing import Never
 
 import aiohttp_jinja2
 from aiohttp import web
@@ -11,9 +11,6 @@ from questionpy_common.environment import RequestUser
 from questionpy_sdk.webserver._form_data import get_nested_form_data, parse_form_data
 from questionpy_sdk.webserver.app import SDK_WEBSERVER_APP_KEY, WebServer
 from questionpy_sdk.webserver.context import contextualize
-
-if TYPE_CHECKING:
-    from questionpy_server.worker.worker import Worker
 
 routes = web.RouteTableDef()
 
@@ -24,7 +21,6 @@ async def render_options(request: web.Request) -> web.Response:
     webserver = request.app[SDK_WEBSERVER_APP_KEY]
     question_state = webserver.load_question_state()
 
-    worker: Worker
     async with webserver.worker_pool.get_worker(webserver.package_location, 0, None) as worker:
         manifest = await worker.get_manifest()
         form_definition, form_data = await worker.get_options_form(RequestUser(["de", "en"]), question_state)
@@ -39,7 +35,6 @@ async def render_options(request: web.Request) -> web.Response:
 
 async def _save_updated_form_data(form_data: dict, webserver: "WebServer") -> None:
     old_state = webserver.load_question_state()
-    worker: Worker
     async with webserver.worker_pool.get_worker(webserver.package_location, 0, None) as worker:
         question = await worker.create_question_from_options(RequestUser(["de", "en"]), old_state, form_data=form_data)
 


### PR DESCRIPTION
Warum deklarieren wir nochmal überall `worker` vor einem `with`?

Die innere `worker`-Variable shadowed doch auch eh die äußere...
Oder übersehe ich hier irgendwas?

https://github.com/questionpy-org/questionpy-server/pull/100