### PR TITLE
Quellcode-Verzeichnisse beim Ausführen implizit bauen

### DIFF
--- a/questionpy_sdk/commands/_helper.py
+++ b/questionpy_sdk/commands/_helper.py
@@ -10,6 +10,9 @@ from pydantic import ValidationError
 
 from questionpy_common.constants import DIST_DIR, MANIFEST_FILENAME
 from questionpy_common.manifest import Manifest
+from questionpy_sdk.package.builder import DirPackageBuilder
+from questionpy_sdk.package.errors import PackageBuildError, PackageSourceValidationError
+from questionpy_sdk.package.source import PackageSource
 from questionpy_server.worker.runtime.package_location import (
     DirPackageLocation,
     FunctionPackageLocation,
@@ -18,29 +21,51 @@ from questionpy_server.worker.runtime.package_location import (
 )
 
 
-def infer_package_kind(string: str) -> PackageLocation:
-    path = Path(string)
-    if path.is_dir():
+def build_dir_package(source_path: Path) -> None:
+    try:
+        package_source = PackageSource(source_path)
+    except PackageSourceValidationError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    try:
+        with DirPackageBuilder(package_source) as builder:
+            builder.write_package()
+    except PackageBuildError as exc:
+        msg = f"Failed to build package: {exc}"
+        raise click.ClickException(msg) from exc
+
+
+def infer_package_kind(pkg_string: str) -> PackageLocation:
+    pkg_path = Path(pkg_string)
+
+    if pkg_path.is_dir():
         try:
-            with (path / DIST_DIR / MANIFEST_FILENAME).open() as fp:
-                manifest = Manifest.model_validate_json(fp.read())
-        except FileNotFoundError as exc:
-            msg = "Could not find package manifest. Did you forget to build the package?"
-            raise click.ClickException(msg) from exc
+            manifest_path = pkg_path / DIST_DIR / MANIFEST_FILENAME
+            try:
+                manifest_fp = manifest_path.open()
+            except FileNotFoundError:
+                # build package if needed
+                build_dir_package(pkg_path)
+                click.echo(f"Successfully built package '{pkg_string}'.")
+                manifest_fp = manifest_path.open()
+            manifest = Manifest.model_validate_json(manifest_fp.read())
+            return DirPackageLocation(pkg_path, manifest)
         except (OSError, ValidationError, ValueError) as exc:
-            msg = "Failed to read package manifest."
+            msg = f"Failed to read package manifest:\n{exc}"
             raise click.ClickException(msg) from exc
-        return DirPackageLocation(path, manifest)
+        finally:
+            if manifest_fp:
+                manifest_fp.close()
 
-    if zipfile.is_zipfile(path):
-        return ZipPackageLocation(path)
+    if zipfile.is_zipfile(pkg_path):
+        return ZipPackageLocation(pkg_path)
 
-    if ":" in string:
+    if ":" in pkg_string:
         # Explicitly provided init function name.
-        module_name, function_name = string.rsplit(":", maxsplit=1)
+        module_name, function_name = pkg_string.rsplit(":", maxsplit=1)
     else:
         # Default init function name.
-        module_name, function_name = string, "init"
+        module_name, function_name = pkg_string, "init"
 
     # https://stackoverflow.com/a/14050282/5390250
     try:
@@ -52,7 +77,7 @@ def infer_package_kind(string: str) -> PackageLocation:
     if module_spec:
         return FunctionPackageLocation(module_name, function_name)
 
-    msg = f"'{string}' doesn't look like a QPy package zip file, directory or module"
+    msg = f"'{pkg_string}' doesn't look like a QPy package zip file, directory or module"
     raise click.ClickException(msg)
 
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+from questionpy_common.constants import DIST_DIR, MANIFEST_FILENAME
 from questionpy_sdk.commands.run import run
+from tests.cli.conftest import long_running_cmd
 
 
 def test_run_no_arguments(runner: CliRunner) -> None:
@@ -28,8 +30,9 @@ def test_run_non_zip_file(runner: CliRunner, cwd: Path) -> None:
     assert "'README.md' doesn't look like a QPy package zip file, directory or module" in result.stdout
 
 
-def test_run_dir_without_manifest(runner: CliRunner, cwd: Path) -> None:
-    (cwd / "tests").mkdir()
-    result = runner.invoke(run, ["tests"])
-    assert result.exit_code != 0
-    assert "Could not find package manifest" in result.stdout
+def test_run_dir_builds_package(source_path: Path) -> None:
+    with long_running_cmd(["run", str(source_path)]) as proc:
+        assert proc.stdout
+        first_line = proc.stdout.readline().decode("utf-8")
+        assert f"Successfully built package '{source_path}'" in first_line
+        assert (source_path / DIST_DIR / MANIFEST_FILENAME).exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def source_path(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
     marker = request.node.get_closest_marker("source_pkg")
     example_pkg = "minimal" if marker is None else marker.args[0]
 
-    src_path = Path(__file__).parent.parent.parent / "examples" / example_pkg
+    src_path = Path(__file__).parent.parent / "examples" / example_pkg
     dest_path = tmp_path / example_pkg
     copytree(src_path, dest_path, ignore=lambda src, names: (DIST_DIR,))
 

--- a/tests/package/conftest.py
+++ b/tests/package/conftest.py
@@ -7,6 +7,8 @@ from shutil import copytree
 
 import pytest
 
+from questionpy_common.constants import DIST_DIR
+
 
 @pytest.fixture
 def source_path(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
@@ -15,6 +17,6 @@ def source_path(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
 
     src_path = Path(__file__).parent.parent.parent / "examples" / example_pkg
     dest_path = tmp_path / example_pkg
-    copytree(src_path, dest_path)
+    copytree(src_path, dest_path, ignore=lambda src, names: (DIST_DIR,))
 
     return dest_path


### PR DESCRIPTION
Baut ein dir package on-the-fly, wenn keine Manifest-Datei in `dist` gefunden werden kann.

Issue: #96 