### PR TITLE
Refaktorisierung Question UI: Argumente von render nach init verschieben

### DIFF
--- a/questionpy_sdk/webserver/attempt.py
+++ b/questionpy_sdk/webserver/attempt.py
@@ -37,6 +37,8 @@ def get_attempt_render_context(
     seed: int,
     disabled: bool,
 ) -> _AttemptRenderContext:
+    renderer_args = (attempt.ui.placeholders, display_options, seed, last_attempt_data)
+
     context: _AttemptRenderContext = {
         "attempt_status": (
             "Started"
@@ -48,9 +50,7 @@ def get_attempt_render_context(
         "attempt_state": attempt_state,
         "options": display_options.model_dump(exclude={"context", "readonly"}),
         "form_disabled": disabled,
-        "formulation": QuestionFormulationUIRenderer(
-            attempt.ui.formulation, attempt.ui.placeholders, display_options, seed, last_attempt_data
-        ).render(),
+        "formulation": QuestionFormulationUIRenderer(attempt.ui.formulation, *renderer_args).xml,
         "attempt": attempt,
         "general_feedback": None,
         "specific_feedback": None,
@@ -58,16 +58,10 @@ def get_attempt_render_context(
     }
 
     if display_options.general_feedback and attempt.ui.general_feedback:
-        context["general_feedback"] = QuestionUIRenderer(
-            attempt.ui.general_feedback, attempt.ui.placeholders, display_options, seed, last_attempt_data
-        ).render()
+        context["general_feedback"] = QuestionUIRenderer(attempt.ui.general_feedback, *renderer_args).xml
     if display_options.feedback and attempt.ui.specific_feedback:
-        context["specific_feedback"] = QuestionUIRenderer(
-            attempt.ui.specific_feedback, attempt.ui.placeholders, display_options, seed, last_attempt_data
-        ).render()
+        context["specific_feedback"] = QuestionUIRenderer(attempt.ui.specific_feedback, *renderer_args).xml
     if display_options.right_answer and attempt.ui.right_answer:
-        context["right_answer"] = QuestionUIRenderer(
-            attempt.ui.right_answer, attempt.ui.placeholders, display_options, seed, last_attempt_data
-        ).render()
+        context["right_answer"] = QuestionUIRenderer(attempt.ui.right_answer, *renderer_args).xml
 
     return context

--- a/questionpy_sdk/webserver/attempt.py
+++ b/questionpy_sdk/webserver/attempt.py
@@ -27,7 +27,7 @@ class _AttemptRenderContext(TypedDict):
 def _render_part(
     ui: AttemptUi, part: str, last_attempt_data: dict, display_options: QuestionDisplayOptions, seed: int
 ) -> str:
-    return QuestionUIRenderer(part, ui.placeholders, seed).render(last_attempt_data, display_options)
+    return QuestionUIRenderer(part, ui.placeholders, display_options, seed, last_attempt_data).render()
 
 
 def get_attempt_render_context(

--- a/questionpy_sdk/webserver/attempt.py
+++ b/questionpy_sdk/webserver/attempt.py
@@ -4,8 +4,12 @@
 
 from typing import Literal, TypedDict
 
-from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel, AttemptUi
-from questionpy_sdk.webserver.question_ui import QuestionDisplayOptions, QuestionUIRenderer
+from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel
+from questionpy_sdk.webserver.question_ui import (
+    QuestionDisplayOptions,
+    QuestionFormulationUIRenderer,
+    QuestionUIRenderer,
+)
 from questionpy_server.api.models import AttemptStarted
 
 
@@ -22,12 +26,6 @@ class _AttemptRenderContext(TypedDict):
     general_feedback: str | None
     specific_feedback: str | None
     right_answer: str | None
-
-
-def _render_part(
-    ui: AttemptUi, part: str, last_attempt_data: dict, display_options: QuestionDisplayOptions, seed: int
-) -> str:
-    return QuestionUIRenderer(part, ui.placeholders, display_options, seed, last_attempt_data).render()
 
 
 def get_attempt_render_context(
@@ -50,7 +48,9 @@ def get_attempt_render_context(
         "attempt_state": attempt_state,
         "options": display_options.model_dump(exclude={"context", "readonly"}),
         "form_disabled": disabled,
-        "formulation": _render_part(attempt.ui, attempt.ui.formulation, last_attempt_data, display_options, seed),
+        "formulation": QuestionFormulationUIRenderer(
+            attempt.ui.formulation, attempt.ui.placeholders, display_options, seed, last_attempt_data
+        ).render(),
         "attempt": attempt,
         "general_feedback": None,
         "specific_feedback": None,
@@ -58,16 +58,16 @@ def get_attempt_render_context(
     }
 
     if display_options.general_feedback and attempt.ui.general_feedback:
-        context["general_feedback"] = _render_part(
-            attempt.ui, attempt.ui.general_feedback, last_attempt_data, display_options, seed
-        )
+        context["general_feedback"] = QuestionUIRenderer(
+            attempt.ui.general_feedback, attempt.ui.placeholders, display_options, seed, last_attempt_data
+        ).render()
     if display_options.feedback and attempt.ui.specific_feedback:
-        context["specific_feedback"] = _render_part(
-            attempt.ui, attempt.ui.specific_feedback, last_attempt_data, display_options, seed
-        )
+        context["specific_feedback"] = QuestionUIRenderer(
+            attempt.ui.specific_feedback, attempt.ui.placeholders, display_options, seed, last_attempt_data
+        ).render()
     if display_options.right_answer and attempt.ui.right_answer:
-        context["right_answer"] = _render_part(
-            attempt.ui, attempt.ui.right_answer, last_attempt_data, display_options, seed
-        )
+        context["right_answer"] = QuestionUIRenderer(
+            attempt.ui.right_answer, attempt.ui.placeholders, display_options, seed, last_attempt_data
+        ).render()
 
     return context

--- a/tests/webserver/test_question_ui.py
+++ b/tests/webserver/test_question_ui.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import pytest
 
-from questionpy_sdk.webserver.question_ui import QuestionDisplayOptions, QuestionMetadata, QuestionUIRenderer
+from questionpy_sdk.webserver.question_ui import (
+    QuestionDisplayOptions,
+    QuestionFormulationUIRenderer,
+    QuestionMetadata,
+    QuestionUIRenderer,
+)
 from tests.webserver.conftest import assert_xhtml_is_equal
 
 
@@ -44,8 +49,8 @@ def result(request: pytest.FixtureRequest, xml_content: str | None) -> str:
 
 @pytest.mark.ui_file("metadata")
 def test_should_extract_correct_metadata(xml_content: str) -> None:
-    ui_renderer = QuestionUIRenderer(xml_content, {}, QuestionDisplayOptions())
-    question_metadata = ui_renderer.get_metadata()
+    ui_renderer = QuestionFormulationUIRenderer(xml_content, {}, QuestionDisplayOptions())
+    question_metadata = ui_renderer.metadata
 
     expected_metadata = QuestionMetadata()
     expected_metadata.correct_response = {

--- a/tests/webserver/test_question_ui.py
+++ b/tests/webserver/test_question_ui.py
@@ -44,7 +44,7 @@ def result(request: pytest.FixtureRequest, xml_content: str | None) -> str:
         renderer_kwargs |= marker.kwargs
 
     renderer = QuestionUIRenderer(**renderer_kwargs)
-    return renderer.render()
+    return renderer.xml
 
 
 @pytest.mark.ui_file("metadata")
@@ -149,7 +149,7 @@ def test_element_visibility_based_on_role(user_context: str, expected: str, xml_
     options.context["role"] = user_context
 
     renderer = QuestionUIRenderer(xml_content, {}, options)
-    result = renderer.render()
+    result = renderer.xml
 
     assert_xhtml_is_equal(result, expected)
 
@@ -262,7 +262,7 @@ def test_should_format_floats_in_en(result: str) -> None:
 def test_should_shuffle_the_same_way_in_same_attempt(result: str, xml_content: str) -> None:
     for _ in range(10):
         renderer = QuestionUIRenderer(xml_content, {}, QuestionDisplayOptions(), seed=42)
-        other_result = renderer.render()
+        other_result = renderer.xml
         assert result == other_result, "Shuffled order should remain consistent across renderings with the same seed"
 
 


### PR DESCRIPTION
Die `render` Methode war noch auf die alte XML-Struktur ausgelegt (ein großes XML, aus dem die einzelnen Teile formulation, specific-feedback, etc. extrahiert und transformiert wurden). Mit unserer Aufteilung auf mehrere XML-Daten ist das so nicht mehr notwendig. Ganz konkret kommt hinzu, dass wir für die statischen Dateien (QPy-URLs) noch vor der XML-Transformation im String eine Textersetzung durchführen wollen. Dieser PR dient als Vorbereitung dafür.