### PR TITLE
QPy-URL für statische Dateien unterstützen

### DIFF
--- a/questionpy_sdk/webserver/question_ui.py
+++ b/questionpy_sdk/webserver/question_ui.py
@@ -2,6 +2,7 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
+import re
 from functools import cached_property
 from random import Random
 from typing import Any
@@ -138,6 +139,7 @@ class QuestionUIRenderer:
         attempt: dict | None = None,
     ) -> None:
         """General renderer for the question UI except for the formulation part."""
+        xml = self._replace_qpy_urls(xml)
         self._xml = etree.ElementTree(etree.fromstring(xml))
         self._xpath = etree.XPathDocumentEvaluator(self._xml)
         self._xpath.register_namespace("xhtml", self.XHTML_NAMESPACE)
@@ -165,6 +167,10 @@ class QuestionUIRenderer:
         self._format_floats()
         # TODO: mangle_ids_and_names
         self._clean_up()
+
+    def _replace_qpy_urls(self, xml: str) -> str:
+        """Replace QPY-URLs to package files with SDK-URLs."""
+        return re.sub(r"qpy://(static|static-private)/((?:[a-z_][a-z0-9_]{0,126}/){2})", r"/worker/\2file/\1/", xml)
 
     def _resolve_placeholders(self) -> None:
         """Replace placeholder PIs such as `<?p my_key plain?>` with the appropriate value from `self.placeholders`.

--- a/tests/webserver/question_uis/qpy-urls.xhtml
+++ b/tests/webserver/question_uis/qpy-urls.xhtml
@@ -1,0 +1,9 @@
+<div xmlns="http://www.w3.org/1999/xhtml">
+    <link rel="stylesheet" href="qpy://static/foo/bar/style.css"/>
+    <script src="qpy://static/foo/bar/script.js"></script>
+    <img src="qpy://static-private/acme/example/some/nested/path/img.png"/>
+    <p>qpy://static/acme/example/some/link</p>
+    <p>qpy://static-private/acme/example/some/other/link</p>
+    <p>qpy://test/acme/example/broken/qpy-url</p>
+    <p>qpy://static/broken/example</p>
+</div>

--- a/tests/webserver/test_question_ui.py
+++ b/tests/webserver/test_question_ui.py
@@ -308,3 +308,20 @@ def test_clean_up(result: str) -> None:
         </div>
     """
     assert_xhtml_is_equal(result, expected)
+
+
+@pytest.mark.ui_file("qpy-urls")
+def test_should_replace_qpy_urls(result: str) -> None:
+    expected = """
+        <div>
+            <link rel="stylesheet" href="/worker/foo/bar/file/static/style.css"/>
+            <script src="/worker/foo/bar/file/static/script.js"></script>
+            <img src="/worker/acme/example/file/static-private/some/nested/path/img.png"/>
+            <p>/worker/acme/example/file/static/some/link</p>
+            <p>/worker/acme/example/file/static-private/some/other/link</p>
+            <p>qpy://test/acme/example/broken/qpy-url</p>
+            <p>qpy://static/broken/example</p>
+        </div>
+    """
+
+    assert_xhtml_is_equal(result, expected)


### PR DESCRIPTION
QPY-URLs mit dem Format

> qpy://static/[namespace]/[shortname]/
> qpy://static-private/[namespace]/[shortname]/

werden ersetzt durch

> /worker/[namespace]/[shortname]/file/static/
> /worker/[namespace]/[shortname]/file/static-private/

Der eigentliche Dateipfad hinter dem letzten Slash wird nicht berührt.

closes #93