### PR TITLE
Question-UI: HTML produzieren, und zwar ohne komische `<string>`-Tags

### DIFF
--- a/questionpy_sdk/webserver/attempt.py
+++ b/questionpy_sdk/webserver/attempt.py
@@ -50,7 +50,7 @@ def get_attempt_render_context(
         "attempt_state": attempt_state,
         "options": display_options.model_dump(exclude={"context", "readonly"}),
         "form_disabled": disabled,
-        "formulation": QuestionFormulationUIRenderer(attempt.ui.formulation, *renderer_args).xml,
+        "formulation": QuestionFormulationUIRenderer(attempt.ui.formulation, *renderer_args).html,
         "attempt": attempt,
         "general_feedback": None,
         "specific_feedback": None,
@@ -58,10 +58,10 @@ def get_attempt_render_context(
     }
 
     if display_options.general_feedback and attempt.ui.general_feedback:
-        context["general_feedback"] = QuestionUIRenderer(attempt.ui.general_feedback, *renderer_args).xml
+        context["general_feedback"] = QuestionUIRenderer(attempt.ui.general_feedback, *renderer_args).html
     if display_options.feedback and attempt.ui.specific_feedback:
-        context["specific_feedback"] = QuestionUIRenderer(attempt.ui.specific_feedback, *renderer_args).xml
+        context["specific_feedback"] = QuestionUIRenderer(attempt.ui.specific_feedback, *renderer_args).html
     if display_options.right_answer and attempt.ui.right_answer:
-        context["right_answer"] = QuestionUIRenderer(attempt.ui.right_answer, *renderer_args).xml
+        context["right_answer"] = QuestionUIRenderer(attempt.ui.right_answer, *renderer_args).html
 
     return context

--- a/questionpy_sdk/webserver/question_ui.py
+++ b/questionpy_sdk/webserver/question_ui.py
@@ -127,6 +127,7 @@ class QuestionDisplayOptions(BaseModel):
 
 
 class QuestionUIRenderer:
+    """General renderer for the question UI except for the formulation part."""
     XHTML_NAMESPACE: str = "http://www.w3.org/1999/xhtml"
     QPY_NAMESPACE: str = "http://questionpy.org/ns/question"
 
@@ -138,7 +139,6 @@ class QuestionUIRenderer:
         seed: int | None = None,
         attempt: dict | None = None,
     ) -> None:
-        """General renderer for the question UI except for the formulation part."""
         xml = self._replace_qpy_urls(xml)
         self._xml = etree.ElementTree(etree.fromstring(xml))
         self._xpath = etree.XPathDocumentEvaluator(self._xml)
@@ -150,7 +150,7 @@ class QuestionUIRenderer:
         self._attempt = attempt
 
     @cached_property
-    def xml(self) -> str:
+    def html(self) -> str:
         self._render()
         return etree.tostring(self._xml, pretty_print=True, method="html").decode()
 
@@ -443,6 +443,8 @@ class QuestionUIRenderer:
 
 
 class QuestionFormulationUIRenderer(QuestionUIRenderer):
+    """Renderer for the formulation UI part that provides metadata."""
+
     def __init__(
         self,
         xml: str,
@@ -451,7 +453,6 @@ class QuestionFormulationUIRenderer(QuestionUIRenderer):
         seed: int | None = None,
         attempt: dict | None = None,
     ) -> None:
-        """Renderer for the formulation UI part that provides metadata."""
         super().__init__(xml, placeholders, options, seed, attempt)
         self.metadata = self._get_metadata()
 

--- a/questionpy_sdk/webserver/question_ui.py
+++ b/questionpy_sdk/webserver/question_ui.py
@@ -166,7 +166,7 @@ class QuestionUIRenderer:
         # TODO: mangle_ids_and_names
         self.clean_up(newdoc, xpath)
 
-        return etree.tostring(newdoc, pretty_print=True).decode()
+        return etree.tostring(newdoc, pretty_print=True, method="html").decode()
 
     def resolve_placeholders(self, xpath: etree.XPathDocumentEvaluator) -> None:
         """Replace placeholder PIs such as `<?p my_key plain?>` with the appropriate value from `self.placeholders`.
@@ -210,7 +210,7 @@ class QuestionUIRenderer:
                 if cleaned_value.text:
                     content += cleaned_value.text
                 for child in cleaned_value:
-                    content += etree.tostring(child, encoding="unicode", with_tail=True)
+                    content += etree.tostring(child, encoding="unicode", method="html", with_tail=True)
                 replacement = content
             else:
                 replacement = raw_value

--- a/tests/webserver/conftest.py
+++ b/tests/webserver/conftest.py
@@ -76,12 +76,12 @@ def normalize_element(element: etree._Element) -> etree._Element:
     return element
 
 
-def assert_xhtml_is_equal(xhtml1: str, xhtml2: str) -> None:
-    parser = etree.XMLParser(remove_blank_text=True)
-    tree1 = etree.fromstring(xhtml1, parser)
-    tree2 = etree.fromstring(xhtml2, parser)
+def assert_html_is_equal(actual: str, expected: str) -> None:
+    parser = etree.HTMLParser(remove_blank_text=True)
+    actual_tree = etree.fromstring(actual, parser)
+    expected_tree = etree.fromstring(expected, parser)
 
-    normalize_element(tree1)
-    normalize_element(tree2)
+    normalize_element(actual_tree)
+    normalize_element(expected_tree)
 
-    assert etree.tostring(tree1, method="c14n") == etree.tostring(tree2, method="c14n")
+    assert etree.tostring(actual_tree, method="c14n") == etree.tostring(expected_tree, method="c14n")

--- a/tests/webserver/test_question_ui.py
+++ b/tests/webserver/test_question_ui.py
@@ -44,7 +44,7 @@ def result(request: pytest.FixtureRequest, xml_content: str | None) -> str:
         renderer_kwargs |= marker.kwargs
 
     renderer = QuestionUIRenderer(**renderer_kwargs)
-    return renderer.xml
+    return renderer.html
 
 
 @pytest.mark.ui_file("metadata")
@@ -149,7 +149,7 @@ def test_element_visibility_based_on_role(user_context: str, expected: str, xml_
     options.context["role"] = user_context
 
     renderer = QuestionUIRenderer(xml_content, {}, options)
-    result = renderer.xml
+    result = renderer.html
 
     assert_xhtml_is_equal(result, expected)
 
@@ -262,7 +262,7 @@ def test_should_format_floats_in_en(result: str) -> None:
 def test_should_shuffle_the_same_way_in_same_attempt(result: str, xml_content: str) -> None:
     for _ in range(10):
         renderer = QuestionUIRenderer(xml_content, {}, QuestionDisplayOptions(), seed=42)
-        other_result = renderer.xml
+        other_result = renderer.html
         assert result == other_result, "Shuffled order should remain consistent across renderings with the same seed"
 
 

--- a/tests/webserver/test_question_ui.py
+++ b/tests/webserver/test_question_ui.py
@@ -12,7 +12,7 @@ from questionpy_sdk.webserver.question_ui import (
     QuestionMetadata,
     QuestionUIRenderer,
 )
-from tests.webserver.conftest import assert_xhtml_is_equal
+from tests.webserver.conftest import assert_html_is_equal
 
 
 @pytest.fixture
@@ -83,20 +83,19 @@ def test_should_extract_correct_metadata(xml_content: str) -> None:
     }
 )
 def test_should_resolve_placeholders(result: str) -> None:
-    # TODO: remove <string> surrounding the resolved placeholder
     expected = """
     <div>
-        <div><string>My simple description.</string></div>
-        <span>By default cleaned parameter: <string>Value of param <b>one</b>.</string></span>
-        <span>Explicitly cleaned parameter: <string>Value of param <b>one</b>.</string></span>
-        <span>Noclean parameter: <string>Value of param <b>one</b>.<script>'Oh no, danger!'</script></string></span>
+        <div>My simple description.</div>
+        <span>By default cleaned parameter: Value of param <b>one</b>.</span>
+        <span>Explicitly cleaned parameter: Value of param <b>one</b>.</span>
+        <span>Noclean parameter: Value of param <b>one</b>.<script>'Oh no, danger!'</script></span>
         <span>Plain parameter:
-            <string><![CDATA[Value of param <b>one</b>.<script>'Oh no, danger!'</script>]]></string>
+            Value of param &lt;b>one&lt;/b>.&lt;script>'Oh no, danger!'&lt;/script>
         </span>
     </div>
     """
 
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.ui_file("feedbacks")
@@ -107,7 +106,7 @@ def test_should_hide_inline_feedback(result: str) -> None:
             <span>No feedback</span>
         </div>
     """
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.ui_file("feedbacks")
@@ -119,7 +118,7 @@ def test_should_show_inline_feedback(result: str) -> None:
             <span>Specific feedback</span>
         </div>
     """
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.parametrize(
@@ -151,7 +150,7 @@ def test_element_visibility_based_on_role(user_context: str, expected: str, xml_
     renderer = QuestionUIRenderer(xml_content, {}, options)
     result = renderer.html
 
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.ui_file("inputs")
@@ -180,7 +179,7 @@ def test_should_set_input_values(result: str) -> None:
             <input name="my_radio" type="radio" value="radio_value_2" class="qpy-input" checked="checked"/>
         </div>
     """
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.ui_file("inputs")
@@ -201,7 +200,7 @@ def test_should_disable_inputs(result: str) -> None:
             <input name="my_radio" type="radio" value="radio_value_2" disabled="disabled" class="qpy-input"/>
         </div>
     """
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.ui_file("validations")
@@ -220,7 +219,7 @@ def test_should_soften_validations(result: str) -> None:
         </div>
     """
 
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.ui_file("buttons")
@@ -236,7 +235,7 @@ def test_should_defuse_buttons(result: str) -> None:
             <input class="btn btn-primary qpy-input" type="button" value="Button"/>
         </div>
     """
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.skip("""1. The text directly in the root of <qpy:formulation> is not copied in render_part.
@@ -254,7 +253,7 @@ def test_should_format_floats_in_en(result: str) -> None:
             Strip zeros: <span>1.1</span>
         </div>
     """
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.ui_file("shuffle")
@@ -287,7 +286,7 @@ def test_should_replace_shuffled_index(result: str) -> None:
             </fieldset>
         </div>
         """
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.render_params(
@@ -307,7 +306,7 @@ def test_clean_up(result: str) -> None:
             <regular>Normal Content</regular>
         </div>
     """
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)
 
 
 @pytest.mark.ui_file("qpy-urls")
@@ -324,4 +323,4 @@ def test_should_replace_qpy_urls(result: str) -> None:
         </div>
     """
 
-    assert_xhtml_is_equal(result, expected)
+    assert_html_is_equal(result, expected)


### PR DESCRIPTION
Integriert @tx0c3's fix #86 (Vielen Dank dafür, sorry dass das so lange gedauert hat.), passt die Tests darauf an und korrigiert das sehr komische Verhalten, dass `_resolve_placeholders` die Placeholder-Werte in `<string>`- Tags wickelt, die es so in HTML nicht gibt. Ich vermute letzteres ist dem crappigen Design von LXML geschuldet, aber diese Lösung dürfte korrekter sein.