### PR TITLE
Das `questionpy-sdk run`-Kommando kann jetzt direkt auf dist-Verzeichnisse aufgerufen werden

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1200,7 +1200,7 @@ files = [
 
 [[package]]
 name = "questionpy-server"
-version = "0.2.5"
+version = "0.2.6"
 description = "QuestionPy application server"
 optional = false
 python-versions = "^3.11"
@@ -1220,8 +1220,8 @@ watchdog = "^4.0.0"
 [package.source]
 type = "git"
 url = "https://github.com/questionpy-org/questionpy-server.git"
-reference = "763c15bcf3906ebb80d8d0bd9c15e842de4f8b0c"
-resolved_reference = "763c15bcf3906ebb80d8d0bd9c15e842de4f8b0c"
+reference = "263750b29fb5ac3b883422141bed13cdb3bd0706"
+resolved_reference = "263750b29fb5ac3b883422141bed13cdb3bd0706"
 
 [[package]]
 name = "ruff"
@@ -1551,4 +1551,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f1da0050fb6b89dc4e61b25719cf0363b1a7e8052c8c8322732bdb2f5f8046d6"
+content-hash = "0d8d0b2c13c96867ebe1e0311cc33e109c48dc4a9538987388f6bce355a82b7f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Library and toolset for the development of QuestionPy packages"
 authors = ["innoCampus <info@isis.tu-berlin.de>"]
 license = "MIT"
 homepage = "https://questionpy.org"
-version = "0.2.5"
+version = "0.2.6"
 packages = [
     { include = "questionpy" },
     { include = "questionpy_sdk" }
@@ -28,7 +28,7 @@ python = "^3.11"
 aiohttp = "^3.9.3"
 pydantic = "^2.6.4"
 PyYAML = "^6.0.1"
-questionpy-server = { git = "https://github.com/questionpy-org/questionpy-server.git", rev = "763c15bcf3906ebb80d8d0bd9c15e842de4f8b0c" }
+questionpy-server = { git = "https://github.com/questionpy-org/questionpy-server.git", rev = "263750b29fb5ac3b883422141bed13cdb3bd0706" }
 jinja2 = "^3.1.3"
 aiohttp-jinja2 = "^1.6"
 lxml = "~5.1.0"

--- a/questionpy_sdk/commands/run.py
+++ b/questionpy_sdk/commands/run.py
@@ -2,6 +2,8 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
+from pathlib import Path
+
 import click
 
 from questionpy_sdk.commands._helper import get_package_location
@@ -19,5 +21,6 @@ def run(package: str) -> None:
     - a dist directory, or
     - a source directory (built on-the-fly).
     """  # noqa: D301
-    web_server = WebServer(get_package_location(package))
+    pkg_path = Path(package).resolve()
+    web_server = WebServer(get_package_location(package, pkg_path))
     web_server.start_server()

--- a/questionpy_sdk/commands/run.py
+++ b/questionpy_sdk/commands/run.py
@@ -4,12 +4,20 @@
 
 import click
 
-from questionpy_sdk.commands._helper import infer_package_kind
+from questionpy_sdk.commands._helper import get_package_location
 from questionpy_sdk.webserver.app import WebServer
 
 
 @click.command()
 @click.argument("package")
 def run(package: str) -> None:
-    web_server = WebServer(infer_package_kind(package))
+    """Run a package.
+
+    \b
+    PACKAGE can be:
+    - a .qpy file,
+    - a dist directory, or
+    - a source directory (built on-the-fly).
+    """  # noqa: D301
+    web_server = WebServer(get_package_location(package))
     web_server.start_server()

--- a/questionpy_sdk/package/source.py
+++ b/questionpy_sdk/package/source.py
@@ -2,6 +2,7 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
+from functools import cached_property
 from pathlib import Path
 
 import yaml
@@ -28,7 +29,6 @@ class PackageSource:
             PackageSourceValidationError: If the package source could not be validated.
         """
         self._path = path
-        self._config = self._read_yaml_config()
         self._validate()
 
     def _validate(self) -> None:
@@ -36,33 +36,13 @@ class PackageSource:
 
     def _check_required_paths(self) -> None:
         # check for `python/NAMESPACE/SHORTNAME/__init__.py`
-        package_init_path = self._path / "python" / self._config.namespace / self._config.short_name / "__init__.py"
-        try:
-            package_init_path.stat()
-        except FileNotFoundError as exc:
-            msg = f"Expected '{package_init_path}' to exist"
-            raise PackageSourceValidationError(msg) from exc
+        package_init_path = self._path / "python" / self.config.namespace / self.config.short_name / "__init__.py"
         if not package_init_path.is_file():
-            msg = f"Expected '{package_init_path}' to be a file"
+            msg = f"Expected '{package_init_path}' to exist"
             raise PackageSourceValidationError(msg)
 
-    @property
+    @cached_property
     def config(self) -> PackageConfig:
-        return self._config
-
-    @property
-    def config_path(self) -> Path:
-        return self._path / PACKAGE_CONFIG_FILENAME
-
-    @property
-    def normalized_filename(self) -> str:
-        return create_normalized_filename(self._config)
-
-    @property
-    def path(self) -> Path:
-        return self._path
-
-    def _read_yaml_config(self) -> PackageConfig:
         try:
             with self.config_path.open() as config_file:
                 return PackageConfig.model_validate(yaml.safe_load(config_file))
@@ -76,3 +56,15 @@ class PackageSource:
             # TODO: pretty error feedback (https://docs.pydantic.dev/latest/errors/errors/#customize-error-messages)
             msg = f"Failed to validate package config '{self.config_path}': {exc}"
             raise PackageSourceValidationError(msg) from exc
+
+    @property
+    def config_path(self) -> Path:
+        return self._path / PACKAGE_CONFIG_FILENAME
+
+    @property
+    def normalized_filename(self) -> str:
+        return create_normalized_filename(self.config)
+
+    @property
+    def path(self) -> Path:
+        return self._path


### PR DESCRIPTION
- Wenn Zielpfad eine `qpy_manifest.json` beinhaltet, wird es als dist-Verzeichnis behandelt.
- ~Beinhaltet außerdem #108~
- Kleinere Refactorings in `questionpy_sdk/package/source.py`.
- `FunctionPackageLocation` wird nicht länger untersützt als Argument für `run`.
- `infer_package_kind` umbenannt nach `get_package_location`.
- Tests
  - Tests für `run`-Kommando
    - Testet, ob der Webserver läuft.
    - Test für dist-Verzeichnis hinzugefügt.
  - `long_running_cmd` umgeschrieben, so dass Tests in jedem Fall nach einem Timeout terminieren.

Hängt ab von: https://github.com/questionpy-org/questionpy-server/pull/107