### PR TITLE
fix: store static file path relative to dist dir in manifest

### DIFF
--- a/questionpy_sdk/package/builder.py
+++ b/questionpy_sdk/package/builder.py
@@ -158,7 +158,7 @@ class PackageBuilderBase(AbstractContextManager):
             if add_to_static_files:
                 mime_type = guess_type(source_file)[0]
                 file_size = source_file.stat().st_size
-                path_in_dist = str(path_in_pkg.relative_to(Path(DIST_DIR, "static")))
+                path_in_dist = str(path_in_pkg.relative_to(DIST_DIR))
                 self._static_files[path_in_dist] = PackageFile(mime_type=mime_type, size=file_size)
 
     @staticmethod

--- a/tests/questionpy_sdk/package/test_builder.py
+++ b/tests/questionpy_sdk/package/test_builder.py
@@ -125,10 +125,10 @@ def test_writes_manifest(qpy_pkg_path: Path) -> None:
         manifest = Manifest.model_validate_json(manifest_file.read())
 
     assert manifest.short_name == "static_files_example"
-    assert manifest.static_files["css/styles.css"].mime_type == "text/css"
-    assert manifest.static_files["css/styles.css"].size > 0
-    assert manifest.static_files["js/test.js"].mime_type == "text/javascript"
-    assert manifest.static_files["js/test.js"].size > 0
+    assert manifest.static_files["static/css/styles.css"].mime_type == "text/css"
+    assert manifest.static_files["static/css/styles.css"].size > 0
+    assert manifest.static_files["static/js/test.js"].mime_type == "text/javascript"
+    assert manifest.static_files["static/js/test.js"].size > 0
 
 
 def test_runs_pre_build_hook(tmp_path: Path, source_path: Path) -> None:


### PR DESCRIPTION
Statische Dateien müssen immer mit dem Prefix "static/" im Manifest gespeichert werden.