### PR TITLE
More renderer errors

### DIFF
--- a/questionpy_sdk/webserver/question_ui/errors.py
+++ b/questionpy_sdk/webserver/question_ui/errors.py
@@ -5,8 +5,8 @@ import html
 import logging
 from abc import ABC, abstractmethod
 from bisect import insort
-from collections.abc import Iterable, Iterator, Sized
-from dataclasses import dataclass
+from collections.abc import Collection, Iterable, Iterator, Mapping, Sized
+from dataclasses import dataclass, field
 from operator import attrgetter
 from typing import TypeAlias
 
@@ -15,9 +15,22 @@ from lxml import etree
 _log = logging.getLogger(__name__)
 
 
+def _comma_separated_values(values: Collection[str], opening: str, closing: str) -> str:
+    *values, last_value = values
+    last_value = f"{opening}{last_value}{closing}"
+    if not values:
+        return last_value
+
+    return opening + f"{closing}, {opening}".join(values) + f"{closing} and {last_value}"
+
+
 @dataclass(frozen=True)
 class RenderError(ABC):
     """Represents a generic error which occurred during rendering."""
+
+    @property
+    def type(self) -> str:
+        return self.__class__.__name__
 
     @property
     @abstractmethod
@@ -41,10 +54,36 @@ class RenderError(ABC):
 
 @dataclass(frozen=True)
 class RenderElementError(RenderError, ABC):
+    """Represents a generic element error which occurred during rendering."""
+
     element: etree._Element
+    template: str
+    kwargs: Mapping[str, str | Collection[str]] = field(default_factory=dict)
+
+    def _message(self, *, as_html: bool) -> str:
+        (opening, closing) = ("<code>", "</code>") if as_html else ("'", "'")
+        kwargs = {"element": f"{opening}{self.element_representation}{closing}"}
+
+        for key, values in self.kwargs.items():
+            collection = {values} if isinstance(values, str) else values
+            kwargs[key] = _comma_separated_values(collection, opening, closing)
+
+        return self.template.format(**kwargs)
+
+    @property
+    def message(self) -> str:
+        return self._message(as_html=False)
+
+    @property
+    def html_message(self) -> str:
+        return self._message(as_html=True)
 
     @property
     def element_representation(self) -> str:
+        # Return the whole element if it is a PI.
+        if isinstance(self.element, etree._ProcessingInstruction):
+            return str(self.element)
+
         # Create the prefix of an element. We do not want to keep 'html' as a prefix.
         prefix = f"{self.element.prefix}:" if self.element.prefix and self.element.prefix != "html" else ""
         return prefix + etree.QName(self.element).localname
@@ -57,36 +96,84 @@ class RenderElementError(RenderError, ABC):
 
 @dataclass(frozen=True)
 class InvalidAttributeValueError(RenderElementError):
-    """Invalid attribute value."""
+    """Invalid attribute value(s)."""
 
-    attribute: str
-    value: str
-    expected: Iterable[str] | None = None
+    def __init__(
+        self,
+        element: etree._Element,
+        attribute: str,
+        value: str | Collection[str],
+        expected: Collection[str] | None = None,
+    ):
+        kwargs = {"value": value, "attribute": attribute}
+        expected_str = ""
+        if expected:
+            kwargs["expected"] = expected
+            expected_str = " Expected values are {expected}."
 
-    def _message(self, *, as_html: bool) -> str:
-        if as_html:
-            (opening, closing) = ("<code>", "</code>")
-            value = html.escape(self.value)
-        else:
-            (opening, closing) = ("'", "'")
-            value = self.value
-
-        expected = ""
-        if self.expected:
-            expected = f" Expected one of [{opening}" + f"{closing}, {opening}".join(self.expected) + f"{closing}]."
-
-        return (
-            f"Invalid value {opening}{value}{closing} for attribute {opening}{self.attribute}{closing} "
-            f"on element {opening}{self.element_representation}{closing}.{expected}"
+        s = "" if isinstance(value, str) or len(value) <= 1 else ""
+        super().__init__(
+            element=element,
+            template=f"Invalid value{s} {{value}} for attribute {{attribute}} on element {{element}}.{expected_str}",
+            kwargs=kwargs,
         )
 
-    @property
-    def message(self) -> str:
-        return self._message(as_html=False)
 
-    @property
-    def html_message(self) -> str:
-        return self._message(as_html=True)
+@dataclass(frozen=True)
+class ConversionError(RenderElementError):
+    """Could not convert a value to another type."""
+
+    def __init__(self, element: etree._Element, value: str, to_type: type, attribute: str | None = None):
+        kwargs = {"value": value, "type": to_type.__name__}
+
+        in_attribute = ""
+        if attribute:
+            kwargs["attribute"] = attribute
+            in_attribute = " in attribute {attribute}"
+
+        template = f"Unable to convert {{value}} to {{type}}{in_attribute} at element {{element}}."
+        super().__init__(element=element, template=template, kwargs=kwargs)
+
+
+@dataclass(frozen=True)
+class PlaceholderReferenceError(RenderElementError):
+    """A placeholder was referenced which was not provided."""
+
+    def __init__(self, element: etree._Element, placeholder: str, available: Collection[str]):
+        provided = "No placeholders were provided."
+        if len(available) == 1:
+            provided = "There is only one provided placeholder: {available}."
+        elif len(available) > 1:
+            provided = "These are the provided placeholders: {available}."
+
+        super().__init__(
+            element=element,
+            template=f"Referenced placeholder {{placeholder}} was not found. {provided}",
+            kwargs={"placeholder": placeholder, "available": available},
+        )
+
+
+@dataclass(frozen=True)
+class InvalidCleanOptionError(RenderElementError):
+    """Invalid clean option."""
+
+    def __init__(self, element: etree._Element, option: str, expected: Collection[str]):
+        super().__init__(
+            element=element,
+            template="Invalid cleaning option {option}. Available options are {expected}.",
+            kwargs={"option": option, "expected": expected},
+        )
+
+
+@dataclass(frozen=True)
+class UnknownElementError(RenderElementError):
+    """Unknown element with qpy-namespace."""
+
+    def __init__(self, element: etree._Element):
+        super().__init__(
+            element=element,
+            template="Unknown element {element}.",
+        )
 
 
 @dataclass(frozen=True)
@@ -106,11 +193,11 @@ class XMLSyntaxError(RenderError):
 
     @property
     def message(self) -> str:
-        return f"Syntax error: {self.error.msg}"
+        return f"{self.error.msg}"
 
     @property
     def html_message(self) -> str:
-        return f"Invalid syntax: <samp>{html.escape(self.error.msg)}</samp>"
+        return f"<samp>{html.escape(self.error.msg)}</samp>"
 
 
 class RenderErrorCollection(Iterable, Sized):
@@ -143,5 +230,7 @@ def log_render_errors(render_errors: RenderErrorCollections) -> None:
         errors_string = ""
         for error in errors:
             line = f"Line {error.line}: " if error.line else ""
-            errors_string += f"\n\t- {line}{error.message}"
-        _log.warning(f"{len(errors)} error(s) occurred while rendering {section}:{errors_string}")
+            errors_string += f"\n\t- {line}{error.type} - {error.message}"
+        error_count = len(errors)
+        s = "s" if error_count > 1 else ""
+        _log.warning(f"{error_count} error{s} occurred while rendering {section}:{errors_string}")

--- a/questionpy_sdk/webserver/question_ui/errors.py
+++ b/questionpy_sdk/webserver/question_ui/errors.py
@@ -64,7 +64,7 @@ class RenderElementError(RenderError, ABC):
             The '{element}' placeholder is predefined and resolves to a human-readable representation of `element`.
             Providing a value with the key 'element' in `template_kwargs` will overwrite this behaviour.
         template_kwargs: A mapping containing the values of the placeholders in `template`.
-            If a value is of type `Collection[str]`, it will be formatted in a human-readable list.
+            If a value is of type `Collection[str]`, it will be formatted as a human-readable list.
     """
 
     element: etree._Element

--- a/questionpy_sdk/webserver/static/styles.css
+++ b/questionpy_sdk/webserver/static/styles.css
@@ -260,23 +260,36 @@ fieldset {
     text-decoration: underline;
 }
 
-.container-render-errors table tr td:first-child,
-.container-render-errors table tr th:first-child:not([scope="rowgroup"]) {
-    border-left: 0;
-    padding-right: 0.5rem;
-}
-
 .container-render-errors table tr td:first-child {
     vertical-align: top;
     text-align: right;
     font-variant-numeric: lining-nums tabular-nums;
 }
 
+.container-render-errors table tr td:first-child,
+.container-render-errors table tr th:first-child:not([scope="rowgroup"]) {
+    border-left: 0;
+    padding-right: 0.5rem;
+}
+
 .container-render-errors table tr td:last-child,
 .container-render-errors table tr th:last-child:not([scope="rowgroup"]) {
     border-right: 0;
     padding-left: 0.5rem;
+}
 
+.container-render-errors table tr td:not(:first-child):not(:last-child),
+.container-render-errors table tr th:not(:first-child):not(:last-child):not([scope="rowgroup"]) {
+    padding: 0 0.5rem;
+    vertical-align: top;
+}
+
+/* If the screen is to small, hide every column expect for the first and last (-> line and error message). */
+@media only screen and (max-width: 60rem) {
+    .container-render-errors table tr td:not(:first-child):not(:last-child),
+    .container-render-errors table tr th:not(:first-child):not(:last-child):not([scope="rowgroup"]) {
+        display: none;
+    }
 }
 
 .container-render-errors table tbody th {

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -22,11 +22,13 @@
                     </tr>
                     <tr>
                         <th>Line</th>
+                        <th>Type</th>
                         <th>Error-Message</th>
                     </tr>
                     {% for error in errors %}
                     <tr>
                         <td>{{ error.line or '' }}</td>
+                        <td>{{ error.type }}</td>
                         <td>{{ error.html_message|safe }}</td>
                     </tr>
                     {% endfor %}

--- a/ruff_defaults.toml
+++ b/ruff_defaults.toml
@@ -106,6 +106,7 @@ pydocstyle = { convention = "google" }
 [lint.per-file-ignores]
 "**/scripts/*" = ["INP001", "T201"]
 "**/tests/**/*" = ["PLC1901", "PLC2701", "PLR2004", "S", "TID252", "FBT"]
+"**/question_ui/errors.py" = ["RUF027"] # Allow f-string without an `f` prefix for our custom error formatter.
 
 [lint.flake8-builtins]
 # help: (guess it's ok since built-in `help()` is for interactive use and no collisions are expected)

--- a/tests/questionpy_sdk/webserver/test_data/faulty.xhtml
+++ b/tests/questionpy_sdk/webserver/test_data/faulty.xhtml
@@ -1,5 +1,14 @@
 <div xmlns="http://www.w3.org/1999/xhtml" xmlns:qpy="http://questionpy.org/ns/question">
     <span qpy:feedback="unknown">Unknown feedback type.</span>
     <span no-attribute-value>Missing attribute value.</span>
-    <span qpy:feedback="unknown">Unknown feedback type.</span>
+    <qpy:unknown-element/>
+    <div>Missing placeholder.<?p missing invalid-cleaning-option?></div>
+    <div qpy:if-role="deviloper|scorsese">Unknown roles.</div>
+    <qpy:format-float thousands-separator="maybe" precision="invalid">Unknown value.</qpy:format-float>
+    <fieldset qpy:shuffle-contents="">
+        <label>
+            Invalid shuffle format.
+            <qpy:shuffled-index format="invalid"/>. A
+        </label>
+    </fieldset>
 </div>

--- a/tests/questionpy_sdk/webserver/test_data/faulty.xhtml
+++ b/tests/questionpy_sdk/webserver/test_data/faulty.xhtml
@@ -1,8 +1,6 @@
 <div xmlns="http://www.w3.org/1999/xhtml" xmlns:qpy="http://questionpy.org/ns/question">
     <span qpy:feedback="unknown">Unknown feedback type.</span>
-    <span no-attribute-value>Missing attribute value.</span>
     <qpy:unknown-element/>
-    <div>Missing placeholder.<?p missing invalid-cleaning-option?></div>
     <div qpy:if-role="deviloper|scorsese">Unknown roles.</div>
     <qpy:format-float thousands-separator="maybe" precision="invalid">Unknown value.</qpy:format-float>
     <fieldset qpy:shuffle-contents="">
@@ -11,4 +9,7 @@
             <qpy:shuffled-index format="invalid"/>. A
         </label>
     </fieldset>
+    <div>Missing placeholder.<?p missing invalid-cleaning-option?></div>
+    <div>Empty placeholder.<?p      ?></div>
+    <span no-attribute-value>Missing attribute value.</span>
 </div>

--- a/tests/questionpy_sdk/webserver/test_question_ui.py
+++ b/tests/questionpy_sdk/webserver/test_question_ui.py
@@ -363,31 +363,33 @@ def test_should_replace_qpy_urls(renderer: QuestionUIRenderer) -> None:
 def test_errors_should_be_collected(renderer: QuestionUIRenderer) -> None:
     expected = """
         <div>
-            <span>Missing attribute value.</span>
+            <fieldset><label>Invalid shuffle format. . A</label></fieldset>
             <div>Missing placeholder.</div>
-            <fieldset><label>Invalid shuffle format.</label></fieldset>
+            <div>Empty placeholder.</div>
+            <span>Missing attribute value.</span>
         </div>
     """
     html, errors = renderer.render()
-    assert len(errors) == 10
+    assert len(errors) == 11
 
     expected_errors: list[tuple[type[RenderError], int]] = [
         # Even though the syntax error occurs after all the other errors, it should be listed first.
-        (XMLSyntaxError, 3),
+        (XMLSyntaxError, 14),
         (InvalidAttributeValueError, 2),
-        (UnknownElementError, 4),
-        (InvalidCleanOptionError, 5),
-        (PlaceholderReferenceError, 5),
-        (InvalidAttributeValueError, 6),
-        (ConversionError, 7),
-        (ConversionError, 7),
-        (InvalidAttributeValueError, 7),
-        (InvalidAttributeValueError, 11),
+        (UnknownElementError, 3),
+        (InvalidAttributeValueError, 4),
+        (ConversionError, 5),
+        (ConversionError, 5),
+        (InvalidAttributeValueError, 5),
+        (InvalidAttributeValueError, 9),
+        (InvalidCleanOptionError, 12),
+        (PlaceholderReferenceError, 12),
+        (PlaceholderReferenceError, 13),
     ]
 
     for actual_error, expected_error in zip(errors, expected_errors, strict=True):
         error_type, line = expected_error
-        assert actual_error.line == line
         assert isinstance(actual_error, error_type)
+        assert actual_error.line == line
 
     assert_html_is_equal(html, expected)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b6fd6961-82c3-4fe1-9e34-9d790cd3e1f2)

Fügt eine "Type"-Spalte hinzu, welche bei zu wenig Platz ausgeblendet wird, und folgende Fehlermeldungen:
- `ConversionError`
- `InvalidCleanOptionError`
- `PlaceholderReferenceError`
- `UnknownElementError`

Nach Auftreten eines Fehlers wird nicht direkt das Element gelöscht, sondern erst weitere potenziellen Fehlerquellen angeschaut und ggf. gesammelt. So werden bei dem folgenden Element drei Fehler ausgegeben (1x `InvalidAttributeError` und 2x `ConversionError`).
`<qpy:format-float thousands-separator="maybe" precision="-1">Not a float.</qpy:format-float>`