### PR TITLE
Isoliere State Dir für run-Tests

### DIFF
--- a/questionpy_sdk/commands/run.py
+++ b/questionpy_sdk/commands/run.py
@@ -1,18 +1,23 @@
 #  This file is part of the QuestionPy SDK. (https://questionpy.org)
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-
 from pathlib import Path
 
 import click
 
 from questionpy_sdk.commands._helper import get_package_location
-from questionpy_sdk.webserver.app import WebServer
+from questionpy_sdk.webserver.app import DEFAULT_STATE_STORAGE_PATH, WebServer
 
 
 @click.command()
 @click.argument("package")
-def run(package: str) -> None:
+@click.option(
+    "--state-storage-path",
+    type=click.Path(path_type=Path, exists=False, file_okay=False, dir_okay=True, resolve_path=True),
+    default=DEFAULT_STATE_STORAGE_PATH,
+    envvar="QPY_STATE_STORAGE_PATH",
+)
+def run(package: str, state_storage_path: Path) -> None:
     """Run a package.
 
     \b
@@ -22,5 +27,5 @@ def run(package: str) -> None:
     - a source directory (built on-the-fly).
     """  # noqa: D301
     pkg_path = Path(package).resolve()
-    web_server = WebServer(get_package_location(package, pkg_path))
+    web_server = WebServer(get_package_location(package, pkg_path), state_storage_path)
     web_server.start_server()

--- a/questionpy_sdk/webserver/app.py
+++ b/questionpy_sdk/webserver/app.py
@@ -51,11 +51,14 @@ class StateFilename(StrEnum):
     LAST_ATTEMPT_DATA = "last_attempt_data.json"
 
 
+DEFAULT_STATE_STORAGE_PATH = Path(__file__).parent / "question_state_storage"
+
+
 class WebServer:
     def __init__(
         self,
         package_location: PackageLocation,
-        state_storage_path: Path = Path(__file__).parent / "question_state_storage",
+        state_storage_path: Path,
     ) -> None:
         # We import here, so we don't have to work around circular imports.
         from questionpy_sdk.webserver.routes.attempt import routes as attempt_routes  # noqa: PLC0415


### PR DESCRIPTION
Die Tests des "run"-Befehls waren bisher nicht vom default state dir oder voneinander isoliert. Dieser PR verwendet für jeden Aufruf von `long_running_cmd` ein eigenes `TemporaryDirectory`.