### PR TITLE
fix: `shuffled-index` in nested `shuffle-contents`

### DIFF
--- a/questionpy_sdk/webserver/question_ui/__init__.py
+++ b/questionpy_sdk/webserver/question_ui/__init__.py
@@ -76,20 +76,22 @@ def _set_element_value(element: etree._Element, value: str, name: str, xpath: et
         element.set("value", value)
 
 
-def _check_shuffled_index_is_in_nested_shuffle_contents(element: etree._Element, index_element: etree._Element) -> bool:
+def _check_shuffled_index_is_in_nested_shuffle_contents(
+    container: etree._Element, index_element: etree._Element
+) -> bool:
     ancestor = index_element.getparent()
-    while ancestor is not None and ancestor != element:
+    while ancestor is not None and ancestor != container:
         if f"{{{_QPY_NAMESPACE}}}shuffle-contents" in ancestor.attrib:
             return True
         ancestor = ancestor.getparent()
     return False
 
 
-def _replace_shuffled_indices(element: etree._Element, index: int) -> None:
+def _replace_shuffled_indices(container: etree._Element, element: etree._Element, index: int) -> None:
     for index_element in _assert_element_list(
         element.xpath(".//qpy:shuffled-index", namespaces={"qpy": _QPY_NAMESPACE})
     ):
-        if _check_shuffled_index_is_in_nested_shuffle_contents(element, index_element):
+        if _check_shuffled_index_is_in_nested_shuffle_contents(container, index_element):
             # The index element is in a nested shuffle-contents.
             # We want it to be replaced with the index of the inner shuffle, so we ignore it for now.
             continue
@@ -408,13 +410,13 @@ class QuestionUIRenderer:
             child_elements = [child for child in element if isinstance(child, etree._Element)]
             self._random.shuffle(child_elements)
 
-            element.attrib.pop(f"{{{_QPY_NAMESPACE}}}shuffle-contents")
-
             # Reinsert shuffled elements, preserving non-element nodes
-            for i, child in enumerate(child_elements):
-                _replace_shuffled_indices(child, i + 1)
+            for i, child in enumerate(child_elements, 1):
+                _replace_shuffled_indices(element, child, i)
                 # Move each child element back to its parent at the correct position
                 element.append(child)
+
+            element.attrib.pop(f"{{{_QPY_NAMESPACE}}}shuffle-contents")
 
     def _clean_up(self) -> None:
         """Removes remaining QuestionPy elements and attributes as well as comments and xmlns declarations."""

--- a/questionpy_sdk/webserver/question_ui/__init__.py
+++ b/questionpy_sdk/webserver/question_ui/__init__.py
@@ -76,10 +76,24 @@ def _set_element_value(element: etree._Element, value: str, name: str, xpath: et
         element.set("value", value)
 
 
+def _check_shuffled_index_is_in_nested_shuffle_contents(element: etree._Element, index_element: etree._Element) -> bool:
+    ancestor = index_element.getparent()
+    while ancestor is not None and ancestor != element:
+        if f"{{{_QPY_NAMESPACE}}}shuffle-contents" in ancestor.attrib:
+            return True
+        ancestor = ancestor.getparent()
+    return False
+
+
 def _replace_shuffled_indices(element: etree._Element, index: int) -> None:
     for index_element in _assert_element_list(
         element.xpath(".//qpy:shuffled-index", namespaces={"qpy": _QPY_NAMESPACE})
     ):
+        if _check_shuffled_index_is_in_nested_shuffle_contents(element, index_element):
+            # The index element is in a nested shuffle-contents.
+            # We want it to be replaced with the index of the inner shuffle, so we ignore it for now.
+            continue
+
         format_style = index_element.get("format", "123")
 
         if format_style == "123":

--- a/tests/questionpy_sdk/webserver/test_data/shuffled-index-nested.xhtml
+++ b/tests/questionpy_sdk/webserver/test_data/shuffled-index-nested.xhtml
@@ -1,0 +1,8 @@
+<div xmlns="http://www.w3.org/1999/xhtml" xmlns:qpy="http://questionpy.org/ns/question" qpy:shuffle-contents="">
+    <p><qpy:shuffled-index format="iii"/>. A</p>
+    <p><qpy:shuffled-index format="iii"/>. B</p>
+    <div qpy:shuffle-contents="">
+        <p><qpy:shuffled-index format="iii"/>. C</p>
+        <p><qpy:shuffled-index format="iii"/>. D</p>
+    </div>
+</div>

--- a/tests/questionpy_sdk/webserver/test_question_ui.py
+++ b/tests/questionpy_sdk/webserver/test_question_ui.py
@@ -319,6 +319,24 @@ def test_should_replace_shuffled_index(renderer: QuestionUIRenderer) -> None:
     assert_html_is_equal(html, expected)
 
 
+@pytest.mark.ui_file("shuffled-index-nested")
+@pytest.mark.render_params(seed=42)
+def test_should_replace_shuffled_index_in_nested(renderer: QuestionUIRenderer) -> None:
+    expected = """
+        <div>
+            <p><span>i</span>. B</p>
+            <p><span>ii</span>. A</p>
+            <div>
+                <p><span>i</span>. D</p>
+                <p><span>ii</span>. C</p>
+            </div>
+        </div>
+        """
+    html, errors = renderer.render()
+    assert len(errors) == 0
+    assert_html_is_equal(html, expected)
+
+
 @pytest.mark.render_params(
     xml="""
         <div xmlns:qpy="http://questionpy.org/ns/question">


### PR DESCRIPTION
In genisteten `shuffle-contents` liegende `shuffled-index` wurden nicht korrekt behandelt.

Dieser PR fixt dieses Problem und fügt noch einen Test hinzu.

Das Plugin-Pendant ist [hier](https://github.com/questionpy-org/moodle-qtype_questionpy/blob/46a1a6ecf546bea36d409f2381b81da5ba871a18/classes/question_ui_renderer.php#L199-L209) zu finden.