### PR TITLE
Keine questionpy -> questionpy_sdk dependencies erlauben

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1266,6 +1266,23 @@ pytest-asyncio = ">=0.17.2"
 testing = ["coverage (==6.2)", "mypy (==0.931)"]
 
 [[package]]
+name = "pytest-archon"
+version = "0.0.6"
+description = "Rule your architecture like a real developer"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-archon-0.0.6.tar.gz", hash = "sha256:5af260a7617fc0a9e8bcd7a62adc42ed1ad466e20ae128b218589f49f73b1bcf"},
+    {file = "pytest_archon-0.0.6-py3-none-any.whl", hash = "sha256:f49b6b1f33a541dda1cab8a733b93b8a712594a002f03283294a624d0b394e83"},
+]
+
+[package.dependencies]
+pytest = ">=7.2"
+
+[package.extras]
+dev = ["black", "check-manifest", "check-wheel-contents", "coverage", "flake8", "mypy", "pyroma"]
+
+[[package]]
 name = "pytest-asyncio"
 version = "0.24.0"
 description = "Pytest support for asyncio"
@@ -1770,4 +1787,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "541327434d7d3eabae4e0936e1dd88bf63462b363b733376ce5ed5d852cc668d"
+content-hash = "13b7eb3dda4a28354933ed63c0ffe0a24fbd1f720e6befca42bfc22750d9d905"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ pytest-md = "^0.2.0"
 coverage = { extras = ["toml"], version = "^7.4.4" }
 selenium = "^4.19.0"
 lxml-stubs = "^0.5.1"
+pytest-archon = "^0.0.6"
 
 [tool.poetry.group.linter]
 dependencies = { ruff = "^0.6.3" }

--- a/questionpy/_ui.py
+++ b/questionpy/_ui.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import jinja2
 
 from questionpy_common.environment import Package, PackageNamespaceAndShortName, get_qpy_environment
-from questionpy_sdk.constants import TEMPLATES_DIR
 
 if TYPE_CHECKING:
     from questionpy import Attempt, Question
@@ -46,7 +45,7 @@ class _TraversableTemplateLoader(jinja2.BaseLoader):
 
 
 def _get_loader(package: Package) -> jinja2.BaseLoader | None:
-    templates_directory = package.get_path(f"{TEMPLATES_DIR}/")
+    templates_directory = package.get_path("templates/")
 
     if not templates_directory.is_dir():
         # The package has no "templates" directory which would cause a template loader to raise an unhelpful ValueError.

--- a/questionpy_sdk/constants.py
+++ b/questionpy_sdk/constants.py
@@ -3,4 +3,3 @@
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
 PACKAGE_CONFIG_FILENAME = "qpy_config.yml"
-TEMPLATES_DIR = "templates"

--- a/questionpy_sdk/package/builder.py
+++ b/questionpy_sdk/package/builder.py
@@ -19,7 +19,6 @@ from types import TracebackType
 import questionpy
 from questionpy_common.constants import DIST_DIR, MANIFEST_FILENAME
 from questionpy_common.manifest import Manifest, PackageFile
-from questionpy_sdk.constants import TEMPLATES_DIR
 from questionpy_sdk.models import BuildHookName
 from questionpy_sdk.package.errors import PackageBuildError
 from questionpy_sdk.package.source import PackageSource
@@ -103,7 +102,7 @@ class PackageBuilderBase(AbstractContextManager):
         """Writes custom package files."""
         static_path = Path(DIST_DIR) / "static"
         self._write_glob(self._source.path, "python/**/*", DIST_DIR)
-        self._write_glob(self._source.path, f"{TEMPLATES_DIR}/**/*", DIST_DIR)
+        self._write_glob(self._source.path, "templates/**/*", DIST_DIR)
         self._write_glob(self._source.path, "css/**/*", static_path, add_to_static_files=True)
         self._write_glob(self._source.path, "js/**/*", static_path, add_to_static_files=True)
         self._write_glob(self._source.path, "static/**/*", DIST_DIR, add_to_static_files=True)

--- a/tests/test_arch.py
+++ b/tests/test_arch.py
@@ -1,0 +1,10 @@
+from pytest_archon import archrule
+
+
+def test_questionpy_should_not_import_sdk() -> None:
+    (
+        archrule("questionpy_should_not_import_sdk", comment="The questionpy package must work without the SDK.")
+        .match("questionpy*")
+        .should_not_import("questionpy_sdk*")
+        .check("questionpy")
+    )


### PR DESCRIPTION
Im Worker gibt es das Paket `questionpy_sdk` nicht, es wird nur `questionpy` in das Paket kopiert. das setzt voraus, dass  das erstere keine Dependency auf das zweitere hat. Das war jetzt durch `TEMPLATES_DIR` wieder der Fall. Statt noch ein drittes `constants.py` anzulegen, habe ich die Konstante erstmal dupliziert und halte das für vertretbar, ist mir aber egal.

Interessanter: Ich habe früher eine Library namens [ArchUnit](https://www.archunit.org/) benutzt und etwas vergleichbares in der Python-Welt gefunden: <https://github.com/jwbargsten/pytest-archon>. Damit habe ich einen Test geschrieben, der questionpy_sdk-Imports aus questionpy in Zukunft verbietet.

Verworfene Ideen:
- Ich hatte erst mit `addaudithook` und dem `import`-Event etwas selbst gebaut. Das funktioniert, ist aber recht unschön und vermutlich nicht robust. 
- <https://github.com/zyskarch/pytestarch> kommt nicht mit zwei Top-Level Paketen klar und könnte immer nur eins von beiden analysieren.
- <https://github.com/seddonym/import-linter>: Für einen Check wollte ich keinen weiteren Build-Step hinzufügen