### PR TITLE
Type-Hints später verwenden

### DIFF
--- a/examples/singlechoice/python/local/singlechoice/question_type.py
+++ b/examples/singlechoice/python/local/singlechoice/question_type.py
@@ -6,6 +6,8 @@ from .form import ChoiceMode, SinglechoiceFormModel
 
 
 class SinglechoiceAttempt(Attempt):
+    question: "SinglechoiceQuestion"
+
     def _compute_score(self) -> float:
         if not self.response or "choice" not in self.response:
             msg = "'choice' is missing"

--- a/questionpy/_attempt.py
+++ b/questionpy/_attempt.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, JsonValue
 from questionpy_common.api.attempt import AttemptFile, AttemptUi, CacheControl, ScoredInputModel, ScoringCode
 
 from ._ui import create_jinja2_environment
-from ._util import get_mro_type_hint
+from ._util import reify_type_hint
 
 if TYPE_CHECKING:
     from ._qtype import Question
@@ -138,8 +138,8 @@ class Attempt(ABC):
     attempt_state: BaseAttemptState
     scoring_state: BaseScoringState | None
 
-    attempt_state_class: ClassVar[type[BaseAttemptState]]
-    scoring_state_class: ClassVar[type[BaseScoringState]]
+    attempt_state_class: ClassVar[type[BaseAttemptState]] = reify_type_hint("attempt_state", BaseAttemptState)
+    scoring_state_class: ClassVar[type[BaseScoringState]] = reify_type_hint("scoring_state", BaseScoringState)
 
     def __init__(
         self,
@@ -245,9 +245,6 @@ class Attempt(ABC):
 
     def __init_subclass__(cls, *args: object, **kwargs: object):
         super().__init_subclass__(*args, **kwargs)
-
-        cls.attempt_state_class = get_mro_type_hint(cls, "attempt_state", BaseAttemptState)
-        cls.scoring_state_class = get_mro_type_hint(cls, "scoring_state", BaseScoringState)
 
 
 class _ScoringError(Exception):

--- a/questionpy/_qtype.py
+++ b/questionpy/_qtype.py
@@ -11,9 +11,8 @@ from questionpy_common.api.question import ScoringMethod, SubquestionModel
 from questionpy_common.environment import get_qpy_environment
 
 from ._attempt import Attempt, AttemptProtocol, AttemptScoredProtocol, AttemptStartedProtocol
-from ._util import get_mro_type_hint
+from ._util import cached_class_property, reify_type_hint
 from .form import FormModel, OptionsFormDefinition
-from .form.validation import validate_form
 
 _F = TypeVar("_F", bound=FormModel)
 _S = TypeVar("_S", bound="BaseQuestionState")
@@ -36,9 +35,11 @@ class Question(ABC):
     options: FormModel
     question_state: BaseQuestionState
 
-    options_class: ClassVar[type[FormModel]]
-    question_state_class: ClassVar[type[BaseQuestionState]]
-    question_state_with_version_class: ClassVar[type[QuestionStateWithVersion]]
+    options_class: ClassVar[type[FormModel]] = reify_type_hint("options", FormModel)
+    question_state_class: ClassVar[type[BaseQuestionState]] = reify_type_hint("question_state", BaseQuestionState)
+    question_state_with_version_class: ClassVar[type[QuestionStateWithVersion]] = cached_class_property(
+        lambda cls: QuestionStateWithVersion[cls.options_class, cls.question_state_class]  # type: ignore[name-defined]
+    )
 
     def __init__(self, qswv: QuestionStateWithVersion) -> None:
         self.question_state_with_version = qswv
@@ -163,17 +164,6 @@ class Question(ABC):
         if not hasattr(cls, "attempt_class"):
             msg = f"Missing '{cls.__name__}.attempt_class' attribute. It should point to your attempt implementation"
             raise TypeError(msg)
-
-        cls.question_state_class = get_mro_type_hint(cls, "question_state", BaseQuestionState)
-        cls.options_class = get_mro_type_hint(cls, "options", FormModel)
-        cls.question_state_with_version_class = QuestionStateWithVersion[  # type: ignore[misc]
-            cls.options_class, cls.question_state_class  # type: ignore[name-defined]
-        ]
-
-        # A form may have unresolved references when it is intended to be used as a repetition, group, section, etc.
-        # Only the complete form must pass validation, so the validation has to happen here instead of in FormModel or
-        # OptionsFormDefinition.
-        validate_form(cls.options_class.qpy_form)
 
     @property  # type: ignore[no-redef]
     def options(self) -> FormModel:

--- a/questionpy/_util.py
+++ b/questionpy/_util.py
@@ -1,11 +1,58 @@
+from collections.abc import Callable
 from types import UnionType
-from typing import TypeVar, get_args, get_type_hints
+from typing import Generic, TypeVar, cast, get_args, get_type_hints
 
-_T = TypeVar("_T", bound=type)
+_TypeT = TypeVar("_TypeT", bound=type)
+_T = TypeVar("_T")
+_UNSET = object()
 
 
-def get_mro_type_hint(klass: type, attr_name: str, bound: _T) -> _T:
-    # FIXME: This function is called too early, when the classes referenced in forward refs may not be defined yet.
+class _CachedClassProperty(Generic[_TypeT, _T]):
+    """See [cached_class_property][]."""
+
+    def __init__(self, getter: Callable[[_TypeT], _T]) -> None:
+        self._getter = getter
+        self._name: str | None = None
+
+    def __get__(self, instance: None, owner: _TypeT) -> _T:
+        if not self._name:
+            return self._getter(owner)
+
+        cached_value = owner.__dict__.get(self._name, _UNSET)
+        if cached_value is _UNSET:
+            value = self._getter(owner)
+            setattr(owner, self._name, value)
+            return value
+
+        return cached_value
+
+    def __set_name__(self, owner: _TypeT, name: str) -> None:
+        self._name = name
+
+
+def cached_class_property(getter: Callable[[_TypeT], _T]) -> _T:
+    """Similar to [functools.cached_property][], but for class properties.
+
+    Like [functools.cached_property][], the descriptor replaces itself with the computed value after the first lookup.
+    """
+    return cast(_T, _CachedClassProperty(getter))
+
+
+def reify_type_hint(attr_name: str, bound: _TypeT) -> _TypeT:
+    """Creates a [cached_class_property][] which returns the type hint of the given attribute."""
+    return cached_class_property(lambda cls: get_mro_type_hint(cls, attr_name, bound))
+
+
+def get_mro_type_hint(klass: type, attr_name: str, bound: _TypeT) -> _TypeT:
+    """Returns the first type hint in `klass`'s MRO for the attribute `attr_name` and checks that it subclasses `bound`.
+
+    For unions (esp. nullable attributes), the union is checked for a member which subclasses `bound` and that is
+    returned. If no such member exists, a `TypeError` is raised.
+
+    Raises:
+        TypeError: If `klass` and its superclasses don't declare an attribute named `attr_name` or if the found type
+                   hint and its union members don't subclass `bound`.
+    """
     for superclass in klass.mro():
         hints = get_type_hints(superclass)
         if attr_name in hints:

--- a/questionpy/_util.py
+++ b/questionpy/_util.py
@@ -16,11 +16,16 @@ class _CachedClassProperty(Generic[_TypeT, _T]):
 
     def __get__(self, instance: None, owner: _TypeT) -> _T:
         if not self._name:
+            # __set_name__ wasn't called. The property is probably not defined in the class body, or wrapped by
+            # something.
             return self._getter(owner)
 
+        # Subsequent lookups _should_ bypass the property entirely, but if for some reason they don't, we check the
+        # class dict explicitly.
         cached_value = owner.__dict__.get(self._name, _UNSET)
         if cached_value is _UNSET:
             value = self._getter(owner)
+            # By setting an attribute on the class, future lookups should bypass the property entirely.
             setattr(owner, self._name, value)
             return value
 

--- a/questionpy/_wrappers/_qtype.py
+++ b/questionpy/_wrappers/_qtype.py
@@ -9,6 +9,7 @@ from pydantic import JsonValue
 
 from questionpy import Question
 from questionpy._wrappers._question import QuestionWrapper
+from questionpy.form.validation import validate_form
 from questionpy_common.api.qtype import InvalidQuestionStateError, QuestionTypeInterface
 from questionpy_common.api.question import QuestionInterface
 from questionpy_common.elements import OptionsFormDefinition
@@ -34,6 +35,12 @@ class QuestionTypeWrapper(QuestionTypeInterface):
                            functionality. This will probably, but not necessarily, be a subclass of the default
                            [QuestionWrapper][questionpy.QuestionWrapper].
         """
+        # A form may have unresolved references when it is intended to be used as a repetition, group, section, etc.
+        # Only the complete form must pass validation, so the validation has to happen here instead of in FormModel or
+        # OptionsFormDefinition.
+        # We also can't do this in Question.__init_subclass__ since the type hint of options may be a forward reference.
+        validate_form(question_class.options_class.qpy_form)
+
         self._question_class = question_class
         self._package = package
 

--- a/tests/questionpy/test_attempt.py
+++ b/tests/questionpy/test_attempt.py
@@ -1,0 +1,27 @@
+from questionpy import Attempt, BaseAttemptState, BaseScoringState
+
+
+class MyAttempt(Attempt):
+    formulation = ""
+
+    def _compute_score(self) -> float:
+        return 1
+
+    # These are forward references, i.e. the types don't exist yet. get_mro_type_hint will support this, as long as it's
+    # called after the types are defined, so it must be called after module execution. We test that we call
+    # get_type_hints correctly.
+    attempt_state: "MyAttemptState"
+    scoring_state: "MyScoringState"
+
+
+class MyAttemptState(BaseAttemptState):
+    pass
+
+
+class MyScoringState(BaseScoringState):
+    pass
+
+
+def test_should_resolve_forward_references() -> None:
+    assert MyAttempt.attempt_state_class is MyAttemptState
+    assert MyAttempt.scoring_state_class is MyScoringState

--- a/tests/questionpy/test_qtype.py
+++ b/tests/questionpy/test_qtype.py
@@ -1,0 +1,28 @@
+from questionpy import BaseQuestionState, Question
+from questionpy._qtype import QuestionStateWithVersion
+from questionpy.form import FormModel
+from tests.questionpy.test_attempt import MyAttempt
+
+
+class MyQuestion(Question):
+    attempt_class = MyAttempt
+
+    # These are forward references, i.e. the types don't exist yet. get_mro_type_hint will support this, as long as it's
+    # called after the types are defined, so it must be called after module execution. We test that we call
+    # get_type_hints correctly.
+    options: "MyFormModel"
+    question_state: "MyQuestionState"
+
+
+class MyFormModel(FormModel):
+    pass
+
+
+class MyQuestionState(BaseQuestionState):
+    pass
+
+
+def test_should_resolve_forward_references() -> None:
+    assert MyQuestion.options_class is MyFormModel
+    assert MyQuestion.question_state_class is MyQuestionState
+    assert MyQuestion.question_state_with_version_class is QuestionStateWithVersion[MyFormModel, MyQuestionState]

--- a/tests/questionpy/wrappers/test_qtype.py
+++ b/tests/questionpy/wrappers/test_qtype.py
@@ -5,7 +5,9 @@ import json
 
 import pytest
 
-from questionpy import OptionsFormValidationError, QuestionTypeWrapper, QuestionWrapper
+from questionpy import OptionsFormValidationError, Question, QuestionTypeWrapper, QuestionWrapper
+from questionpy.form import FormModel, is_not_checked, text_input
+from questionpy.form.validation import FormError
 from questionpy_common.elements import OptionsFormDefinition, TextInputElement
 from questionpy_common.environment import Package
 from tests.questionpy.wrappers.conftest import (
@@ -13,6 +15,7 @@ from tests.questionpy.wrappers.conftest import (
     STATIC_FILES,
     QuestionUsingDefaultState,
     QuestionUsingMyQuestionState,
+    SomeAttempt,
 )
 
 _EXPECTED_FORM = OptionsFormDefinition(general=[TextInputElement(name="input", label="Some Label")])
@@ -72,3 +75,17 @@ def test_should_preserve_options_when_using_default_question_state(package: Pack
 
 def test_should_get_static_files(package: Package) -> None:
     package.manifest.static_files = STATIC_FILES
+
+
+def test_should_raise_when_form_is_invalid(package: Package) -> None:
+    class ModelWithUnresolvedReference(FormModel):
+        my_text: str | None = text_input("Label", hide_if=is_not_checked("nonexistent_checkbox"))
+
+    class MyQuestion(Question):
+        attempt_class = SomeAttempt
+        options: ModelWithUnresolvedReference
+
+    # There are more detailed validation tests in test_validation.py, here we just ensure that validate_form is called
+    # at the correct place.
+    with pytest.raises(FormError):
+        QuestionTypeWrapper(MyQuestion, package)

--- a/tests/questionpy/wrappers/test_question.py
+++ b/tests/questionpy/wrappers/test_question.py
@@ -9,13 +9,10 @@ import pytest
 from questionpy import (
     InvalidResponseError,
     NeedsManualScoringError,
-    Question,
     QuestionTypeWrapper,
     QuestionWrapper,
     ResponseNotScorableError,
 )
-from questionpy.form import FormModel, is_not_checked, text_input
-from questionpy.form.validation import FormError
 from questionpy_common.api.attempt import AttemptModel, AttemptScoredModel, AttemptStartedModel, AttemptUi, ScoringCode
 from questionpy_common.api.question import QuestionModel, ScoringMethod
 from questionpy_common.environment import Package
@@ -106,16 +103,3 @@ def test_should_export_question_model(package: Package) -> None:
     question_model = question.export()
 
     assert question_model == QuestionModel(lang="en", scoring_method=ScoringMethod.AUTOMATICALLY_SCORABLE)
-
-
-def test_should_raise_when_form_is_invalid() -> None:
-    class ModelWithUnresolvedReference(FormModel):
-        my_text: str | None = text_input("Label", hide_if=is_not_checked("nonexistent_checkbox"))
-
-    # There are more detailed validation tests in test_validation.py, here we just ensure that validate_form is called
-    # at the correct place.
-    with pytest.raises(FormError):
-
-        class MyQuestion(Question):
-            attempt_class = SomeAttempt
-            options: ModelWithUnresolvedReference


### PR DESCRIPTION
Löst diesen Kommentar: 
```python
def get_mro_type_hint(klass: type, attr_name: str, bound: _T) -> _T:
    # FIXME: This function is called too early, when the classes referenced in forward refs may not be defined yet.
```

Fälle wie in tests/questionpy/test_attempt.py und tests/questionpy/test_qtype.py hatten bisher für einen Fehler gesorgt, weil wir die Type-Hints in `__init_subclass__` resolven, was während der Klassen-Erstellung, also dort, wo die Subklasse definiert ist, aufgerufen wird. Zu dem Zeitpunkt könnten forward references a la `options: "MyFormModel"` aber noch ins leere zeigen, wenn `MyFormModel` erst darunter definiert wird. 

Stattdessen habe ich die `*_class`-Attribute zu Klassen-Properties gemacht, sodass die forward references erst aufgelöst werden müssen, wenn sie das erste mal gebraucht werden.

Aus dem gleichen Grund kann ich auch `validate_form` nicht mehr in `Question.__init_subclass__` verorten und habe es nach etwas hin- und herüberlegen nach `QuestionTypeWrapper.__init__` geschoben.