### PR TITLE
feat: enable relative path references in `call_js`

### DIFF
--- a/examples/static-files/python/local/static_files_example/question_type.py
+++ b/examples/static-files/python/local/static_files_example/question_type.py
@@ -5,8 +5,8 @@ from .form import MyModel
 
 class ExampleAttempt(Attempt):
     def _init_attempt(self) -> None:
-        self.call_js("@local/static_files_example/test.js", "initButton", ["mybutton", "hiddenInput", "secret"])
-        self.call_js("@local/static_files_example/test.js", "hello", "world", if_feedback_type=FeedbackType.GENERAL_FEEDBACK)
+        self.call_js("test.js", "initButton", ["mybutton", "hiddenInput", "secret"])
+        self.call_js("test.js", "hello", "world", if_feedback_type=FeedbackType.GENERAL_FEEDBACK)
 
     def _compute_score(self) -> float:
         if not self.response or "hidden_value" not in self.response:

--- a/questionpy/_attempt.py
+++ b/questionpy/_attempt.py
@@ -19,7 +19,7 @@ from questionpy_common.api.attempt import (
 )
 
 from ._ui import create_jinja2_environment
-from ._util import get_mro_type_hint
+from ._util import get_mro_type_hint, get_package_by_attempt
 
 if TYPE_CHECKING:
     from ._qtype import Question
@@ -281,12 +281,17 @@ class Attempt(ABC):
         Args:
             module: JS module name specified as:
                 @[package namespace]/[package short name]/[subdir]/[module name] (full reference) or
-                TODO [subdir]/[module name] (referencing a module within the package where this class is subclassed) or
+                [subdir]/[module name] (referencing a module within the package where this class is subclassed)
             function: Name of a callable value within the JS module
             data: arbitrary data to pass to the function
             if_role: Function is only called if the user has this role.
             if_feedback_type: Function is only called if the user is allowed to view this feedback type.
         """
+        if not module.startswith("@"):
+            # Get current package namespace and short name.
+            package = get_package_by_attempt(self)
+            module = f"@{package.manifest.namespace}/{package.manifest.short_name}/{module.lstrip('/')}"
+
         data_json = None if data is None else json.dumps(data)
         call = JsModuleCall(
             module=module, function=function, data=data_json, if_role=if_role, if_feedback_type=if_feedback_type

--- a/questionpy/_ui.py
+++ b/questionpy/_ui.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING
 
 import jinja2
 
-from questionpy_common.environment import Package, PackageNamespaceAndShortName, get_qpy_environment
+from questionpy._util import get_package_by_attempt
+from questionpy_common.environment import Package, get_qpy_environment
 
 if TYPE_CHECKING:
     from questionpy import Attempt, Question
@@ -75,18 +76,7 @@ def create_jinja2_environment(attempt: "Attempt", question: "Question") -> jinja
     loaders: list[jinja2.BaseLoader] = [_CustomPrefixLoader(mapping=loader_mapping)]
 
     # Get caller package template loader.
-    try:
-        module_parts = attempt.__module__.split(".", maxsplit=2)
-        namespace, short_name, *_ = module_parts
-        key = PackageNamespaceAndShortName(namespace=namespace, short_name=short_name)
-        package = qpy_env.packages[key]
-    except (KeyError, ValueError) as e:
-        msg = (
-            "Current package namespace and shortname could not be determined from '__module__' attribute. Please do "
-            "not modify the '__module__' attribute."
-        )
-        raise ValueError(msg) from e
-
+    package = get_package_by_attempt(attempt)
     if current_package_loader := _get_loader(package):
         loaders.insert(0, current_package_loader)
 

--- a/questionpy/_util.py
+++ b/questionpy/_util.py
@@ -1,5 +1,10 @@
 from types import UnionType
-from typing import TypeVar, get_args, get_type_hints
+from typing import TYPE_CHECKING, TypeVar, get_args, get_type_hints
+
+from questionpy_common.environment import Package, PackageNamespaceAndShortName, get_qpy_environment
+
+if TYPE_CHECKING:
+    from questionpy import Attempt
 
 _T = TypeVar("_T", bound=type)
 
@@ -28,3 +33,18 @@ def get_mro_type_hint(klass: type, attr_name: str, bound: _T) -> _T:
         msg = f"Expected '{klass.__name__}.{attr_name}' to be a subclass of '{bound.__name__}', but was " f"'{hint}'"
         raise TypeError(msg)
     return hint
+
+
+def get_package_by_attempt(attempt: "Attempt") -> Package:
+    """Returns the package in which the attempt was defined."""
+    try:
+        namespace, short_name, *_ = attempt.__module__.split(".", maxsplit=2)
+        env = get_qpy_environment()
+        key = PackageNamespaceAndShortName(namespace=namespace, short_name=short_name)
+        return env.packages[key]
+    except (KeyError, ValueError) as e:
+        msg = (
+            "Current package namespace and shortname could not be determined from '__module__' attribute. Please do "
+            "not modify the '__module__' attribute."
+        )
+        raise ValueError(msg) from e


### PR DESCRIPTION
Closes #151. Abhängig von #149.

Zudem meckert `ruff` damit auch nicht mehr.

