### PR TITLE
feat: check for duplicate input names

### DIFF
--- a/questionpy_sdk/webserver_legacy/question_ui/__init__.py
+++ b/questionpy_sdk/webserver_legacy/question_ui/__init__.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from questionpy_common.api.attempt import DisplayRole
 from questionpy_sdk.webserver_legacy.question_ui.errors import (
     ConversionError,
+    DuplicateNameError,
     ExpectedAncestorError,
     InvalidAttributeValueError,
     InvalidCleanOptionError,
@@ -594,6 +595,7 @@ class _RenderErrorCollector:
         self._validate_shuffle_contents_and_shuffled_index()
         self._validate_format_floats()
         self._look_for_unknown_qpy_elements_and_attributes()
+        self._check_input_names()
 
         return self.errors
 
@@ -740,3 +742,42 @@ class _RenderErrorCollector:
             if unknown_attributes:
                 unknown_attribute_error = UnknownAttributeError(element=element, attributes=unknown_attributes)
                 self.errors.insert(unknown_attribute_error)
+
+    def _check_input_names(self) -> None:
+        """Check if there are only valid input names.
+
+        Duplicate input names are only allowed for `checkbox` and `radio` elements, but only when their types match and
+        they have different values.
+        """
+        # Maps element name to the reference element and the values.
+        name_map: dict[str, tuple[etree._Element, set[str]]] = {}
+
+        for current_element in _assert_element_list(
+            self._xpath("(//xhtml:button | //xhtml:input | //xhtml:select | //xhtml:textarea)[@name]")
+        ):
+            # Get name, type, and value of the current element.
+            name = str(current_element.attrib["name"])
+            current_type = current_element.get("type", "text")
+            current_value = current_element.get("value", "on")
+
+            if name not in name_map:
+                # This name has not been used yet by other elements.
+                name_map[name] = (current_element, {current_value})
+                continue
+
+            # Get type and values of the other element(s) with the same name.
+            other_element, values = name_map[name]
+            other_type = other_element.get("type", "text")
+
+            if current_type not in {"checkbox", "radio"}:
+                # Duplicate names are not allowed for other elements.
+                error = DuplicateNameError(element=current_element, name=name, other_element=other_element)
+                self.errors.insert(error)
+                continue
+
+            # Check that the types match and the value is unique.
+            if other_type != current_type or current_value in values:
+                error = DuplicateNameError(element=current_element, name=name, other_element=other_element)
+                self.errors.insert(error)
+            else:
+                values.add(current_value)

--- a/questionpy_sdk/webserver_legacy/question_ui/errors.py
+++ b/questionpy_sdk/webserver_legacy/question_ui/errors.py
@@ -27,6 +27,16 @@ def _format_human_readable_list(values: Collection[str], opening: str, closing: 
     return opening + f"{closing}, {opening}".join(values) + f"{closing} and {last_value}"
 
 
+def _element_representation(element: etree._Element) -> str:
+    # Return the whole element if it is a PI.
+    if isinstance(element, etree._ProcessingInstruction):
+        return str(element)
+
+    # Create the prefix of an element. We do not want to keep 'html' as a prefix.
+    prefix = f"{element.prefix}:" if element.prefix and element.prefix != "html" else ""
+    return prefix + etree.QName(element).localname
+
+
 @dataclass(frozen=True)
 class RenderError(ABC):
     """Represents a generic error which occurred during rendering."""
@@ -76,7 +86,7 @@ class RenderElementError(RenderError, ABC):
 
     def _message(self, *, as_html: bool) -> str:
         (opening, closing) = ("<code>", "</code>") if as_html else ("'", "'")
-        template_kwargs = {"element": f"{opening}{self.element_representation}{closing}"}
+        template_kwargs = {"element": f"{opening}{_element_representation(self.element)}{closing}"}
 
         for key, values in self.template_kwargs.items():
             collection = {values} if isinstance(values, str) else values
@@ -91,16 +101,6 @@ class RenderElementError(RenderError, ABC):
     @property
     def html_message(self) -> str:
         return self._message(as_html=True)
-
-    @property
-    def element_representation(self) -> str:
-        # Return the whole element if it is a PI.
-        if isinstance(self.element, etree._ProcessingInstruction):
-            return str(self.element)
-
-        # Create the prefix of an element. We do not want to keep 'html' as a prefix.
-        prefix = f"{self.element.prefix}:" if self.element.prefix and self.element.prefix != "html" else ""
-        return prefix + etree.QName(self.element).localname
 
     @property
     def line(self) -> int | None:
@@ -231,6 +231,22 @@ class UnknownAttributeError(RenderElementError):
             element=element,
             template=f"Unknown attribute{s} {{attributes}} on element {{element}}.",
             template_kwargs={"attributes": attributes},
+        )
+
+
+@dataclass(frozen=True)
+class DuplicateNameError(RenderElementError):
+    """Invalid duplicate input name."""
+
+    def __init__(self, element: etree._Element, name: str, other_element: etree._Element):
+        super().__init__(
+            element=element,
+            template="{element} should not have the same name ({name}) like {other_element} at line {line}.",
+            template_kwargs={
+                "name": name,
+                "other_element": _element_representation(other_element),
+                "line": str(other_element.sourceline or "?"),
+            },
         )
 
 

--- a/tests/questionpy_sdk/webserver_legacy/test_data/faulty.xhtml
+++ b/tests/questionpy_sdk/webserver_legacy/test_data/faulty.xhtml
@@ -14,5 +14,7 @@
     <div>Empty placeholder.<?p      ?></div>
     <qpy:shuffled-index/> <!-- Not inside a qpy:shuffle-contents element. -->
     <div qpy:unknown-attribute="">Unknown attribute.</div>
+    <input type="checkbox" name="duplicate"/>
+    <input type="radio" name="duplicate"/>
     <span no-attribute-value>Missing attribute value.</span>
 </div>

--- a/tests/questionpy_sdk/webserver_legacy/test_data/input-values.xhtml
+++ b/tests/questionpy_sdk/webserver_legacy/test_data/input-values.xhtml
@@ -15,8 +15,8 @@
 
     <input type="hidden" name="my_hidden" value="original"/>
 
-    <input name="my_button" type="button" value="value1"/>
-    <input name="my_button" type="button" value="value2"/>
+    <input name="button_1" type="button" value="value1"/>
+    <input name="button_2" type="button" value="value2"/>
 
     <textarea name="my_textarea">original</textarea>
 </div>

--- a/tests/questionpy_sdk/webserver_legacy/test_question_ui.py
+++ b/tests/questionpy_sdk/webserver_legacy/test_question_ui.py
@@ -15,6 +15,7 @@ from questionpy_sdk.webserver_legacy.question_ui import (
 )
 from questionpy_sdk.webserver_legacy.question_ui.errors import (
     ConversionError,
+    DuplicateNameError,
     ExpectedAncestorError,
     InvalidAttributeValueError,
     InvalidCleanOptionError,
@@ -211,8 +212,8 @@ def test_should_set_input_values(renderer: QuestionUIRenderer) -> None:
 
             <input class="form-control qpy-input" type="hidden" name="my_hidden" value="new"/>
 
-            <input class="btn btn-primary qpy-input" name="my_button" type="button" value="value1"/>
-            <input class="btn btn-primary qpy-input" name="my_button" type="button" value="value2"/>
+            <input class="btn btn-primary qpy-input" name="button_1" type="button" value="value1"/>
+            <input class="btn btn-primary qpy-input" name="button_2" type="button" value="value2"/>
 
             <textarea class="form-control qpy-input" name="my_textarea">new</textarea>
         </div>
@@ -243,8 +244,8 @@ def test_should_disable_inputs(renderer: QuestionUIRenderer) -> None:
 
             <input class="form-control qpy-input" type="hidden" name="my_hidden" value="original" disabled="disabled"/>
 
-            <input class="btn btn-primary qpy-input" name="my_button" type="button" value="value1" disabled="disabled"/>
-            <input class="btn btn-primary qpy-input" name="my_button" type="button" value="value2" disabled="disabled"/>
+            <input class="btn btn-primary qpy-input" name="button_1" type="button" value="value1" disabled="disabled"/>
+            <input class="btn btn-primary qpy-input" name="button_2" type="button" value="value2" disabled="disabled"/>
 
             <textarea class="form-control qpy-input" name="my_textarea" disabled="disabled">original</textarea>
         </div>
@@ -390,6 +391,8 @@ def test_errors_should_be_collected(renderer: QuestionUIRenderer) -> None:
             <div>Missing placeholder.</div>
             <div>Empty placeholder.</div>
             <div>Unknown attribute.</div>
+            <input type="checkbox" name="duplicate" class="qpy-input"></input>
+            <input type="radio" name="duplicate" class="qpy-input"></input>
             <span>Missing attribute value.</span>
         </div>
     """  # noqa: E501
@@ -397,7 +400,7 @@ def test_errors_should_be_collected(renderer: QuestionUIRenderer) -> None:
 
     expected_errors: list[tuple[type[RenderError], int]] = [
         # Even though the syntax error occurs after all the other errors, it should be listed first.
-        (XMLSyntaxError, 17),
+        (XMLSyntaxError, 19),
         (InvalidAttributeValueError, 2),
         (UnknownElementError, 3),
         (InvalidAttributeValueError, 4),
@@ -411,6 +414,7 @@ def test_errors_should_be_collected(renderer: QuestionUIRenderer) -> None:
         (PlaceholderReferenceError, 14),
         (ExpectedAncestorError, 15),
         (UnknownAttributeError, 16),
+        (DuplicateNameError, 18),
     ]
 
     assert len(errors) == len(expected_errors)


### PR DESCRIPTION
Damit wir im Plugin eindeutig Werte den Input-Feldern zuweisen können, sollten wir nur doppelte Namen bei `checkbox`- und `radio`-Elementen erlauben. Zusätzlich müssen dafür auch die Werte eindeutig sein.

Folgende `formulation.xhtml.j2`:
```xhtml
<div xmlns="http://www.w3.org/1999/xhtml" xmlns:qpy="http://questionpy.org/ns/question">

    <input type="checkbox" name="character" value="a" />
    <input type="checkbox" name="character" value="b" />
    <input type="text" name="character" />

</div>
```
Führt zu folgender Fehlermeldung:
![image](https://github.com/user-attachments/assets/fb9539cc-7912-4ed8-8aaf-a77d669354a7)

Eigentlich könnten wir auch `<button>` und `<input type="button" />` mit dem selben Namen und sogar selben Wert (`value`) erlauben, da wir im Plugin für diese Elemente keinen Wert setzen. Da dieser PR aber von [diesem Issue](https://github.com/questionpy-org/moodle-qtype_questionpy/issues/144) entstammt, wollte ich diesen Teil nicht auch in diesem PR implementieren.