### PR TITLE
Hängende e2e-Tests fixen

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -3,7 +3,9 @@
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
 import asyncio
+import sys
 import threading
+import warnings
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any, TypeVar, cast
@@ -46,10 +48,31 @@ def start_runner(web_app: WebServer) -> None:
 
 
 @pytest.fixture
-def _start_runner_thread(sdk_web_server: WebServer) -> None:
-    app_thread = threading.Thread(target=start_runner, args=(sdk_web_server,))
-    app_thread.daemon = True  # Set the thread as a daemon to automatically stop when main thread exits
+def _webserver_thread(sdk_web_server: WebServer) -> Iterator[None]:
+    loop = asyncio.new_event_loop()
+    app_thread = threading.Thread(
+        target=loop.run_forever,
+        name="SDK WebServer under test",
+        # Set the thread as a daemon to automatically stop when main thread exits
+        daemon=True,
+    )
     app_thread.start()
+
+    asyncio.run_coroutine_threadsafe(sdk_web_server.__aenter__(), loop).result()  # noqa: PLC2801 (manual __aenter__)
+
+    try:
+        yield
+    finally:
+        asyncio.run_coroutine_threadsafe(sdk_web_server.__aexit__(*sys.exc_info()), loop).result()
+        loop.call_soon_threadsafe(loop.stop)
+
+        # After stopping the loop, loop.run_forever should return or raise, causing the thread to end.
+        app_thread.join(2)
+        if app_thread.is_alive():
+            # If it doesn't, the loop and server probably won't be cleaned up, and that's a problem.
+            warnings.warn("WebServer thread for E2E tests did not end gracefully.", stacklevel=1)
+
+        loop.close()
 
 
 _C = TypeVar("_C", bound=Callable)

--- a/tests/e2e/test_options_validation.py
+++ b/tests/e2e/test_options_validation.py
@@ -40,7 +40,7 @@ def await_and_assert_msg(driver: webdriver.Chrome, selector: str) -> None:
     assert el_error.text == "Field required"
 
 
-@pytest.mark.usefixtures("_start_runner_thread")
+@pytest.mark.usefixtures("_webserver_thread")
 @use_package(package_init)
 def test_shows_validation_errors(driver: webdriver.Chrome, url: str) -> None:
     driver.get(url)

--- a/tests/e2e/test_templates.py
+++ b/tests/e2e/test_templates.py
@@ -49,7 +49,7 @@ def package_3_init(package: Package) -> QuestionTypeInterface:
     return QuestionTypeWrapper(Package3Question, package)
 
 
-@pytest.mark.usefixtures("_start_runner_thread")
+@pytest.mark.usefixtures("_webserver_thread")
 class TestTemplates:
     @use_package(package_1_init)
     def test_page_contains_correct_page_title(self, driver: webdriver.Chrome, url: str) -> None:


### PR DESCRIPTION
War: **Fixes für `--without-sources` (#171) und hängende Tasks (#175) / e2e-Tests**

Der Fehler von <https://github.com/questionpy-org/questionpy-sdk/issues/171> löst sich mit <https://github.com/questionpy-org/questionpy-server/pull/145> "von alleine". Leider bin ich damit auch in das Problem gelaufen, dass nach den Tests (Pytest printet schon "100%") der Pytest-Prozess ewig hängt.

Nach etwas debugging stellt sich heraus, dass in den E2E-Tests die Event-Loop, die in einem Daemon-Thread gestartet wird und den WebServer ausführt, nicht korrekt beendet wird. 

~~Außerdem wurde der `WorkerPool` nicht aufgeräumt, ich glaube aber nicht, das das der Grund für die hängenden tests war. Das ist zwar #175 und eigentlich nicht mein Issue, ich habe es aber mitgefixt, um mich selbst zu entblocken.~~

~~Fixes: #171~~
~~Fixes: #175~~

Falls es interressiert, dieser Kniff in der `conftest.py` war ganz hilfreich:
```python
def _print_running_tasks() -> None:  
    print("\nThreads at exit:")  
    threads_by_id = {thread.ident: thread for thread in threading.enumerate()}  
    for thread in threads_by_id.values():  
        print(f"- Thread '{thread.name}' is {'alive' if thread.is_alive() else 'dead'}. daemon={thread.daemon}")  
  
    print("Event loops at exit:")  
    objs = gc.get_objects()  
    loops = [obj for obj in objs if isinstance(obj, asyncio.AbstractEventLoop)]  
  
    for loop in loops:  
        if not loop.is_running():  
            continue  
  
        thread_id = getattr(loop, "_thread_id", None)  
        thread_name = threads_by_id[thread_id].name if thread_id in threads_by_id else None  
        tasks = asyncio.all_tasks(loop)  
        if tasks:  
            print(f"- A loop is running in thread '{thread_name}' and has the following tasks:")  
            for task in tasks:  
                state = ""  
                if task.cancelled():  
                    state = " is cancelled"  
                elif task.done():  
                    state = " is done"  
                elif task.cancelling():  
                    state = " is cancelling"  
  
                print(f"  - Task '{task.get_name()}'{state}")  
  
                if not task.done():  
                    buffer = StringIO()  
                    task.print_stack(file=buffer)  
                    for line in buffer.getvalue().splitlines():  
                        print(f"    {line}")  
        else:  
            print(f"- A loop is running in thread '{thread_name}', but has no tasks.")  
  
  
atexit.register(_print_running_tasks)
```