### PR TITLE
Normale Validation-Attribute benutzen

### DIFF
--- a/questionpy_sdk/webserver/controllers/attempt/question_ui.py
+++ b/questionpy_sdk/webserver/controllers/attempt/question_ui.py
@@ -249,7 +249,6 @@ class QuestionUIRenderer:
 
             # Modify standard HTML.
             self._set_input_values_and_readonly()
-            self._soften_validation()
             self._defuse_buttons()
 
             self._add_styles()
@@ -257,8 +256,6 @@ class QuestionUIRenderer:
             # We don't want to support QPy elements (and attributes, etc.) in placeholder expansions, so we resolve
             # them after replacing QPy elements.
             self._resolve_placeholders()
-
-            # TODO: mangle_ids_and_names
 
             self._html = etree.tostring(self._xml, pretty_print=True, method="html").decode()
             self._error_collector.collect()
@@ -362,42 +359,6 @@ class QuestionUIRenderer:
             last_value = self._attempt.get(name)
             if last_value is not None:
                 _set_element_value(element, last_value)
-
-    def _soften_validation(self) -> None:
-        """Replaces HTML attributes so that submission is not prevented.
-
-        Removes attributes `pattern`, `required`, `minlength`, `maxlength`, `min`, `max` from elements, so form
-        submission is not affected. The standard attributes are replaced with `data-qpy_X`, which are then evaluated in
-        JavaScript.
-        """
-
-        def handle_attribute(
-            elements: list[str], attribute: str, data_attribute: str, aria_attribute: str | None = None
-        ) -> None:
-            xhtml_elems = " | ".join(f".//xhtml:{elem}" for elem in elements)
-            element_list = _assert_element_list(self._xpath(f"({xhtml_elems})[@{attribute}]"))
-            for element in element_list:
-                value = element.get(attribute)
-                element.attrib.pop(attribute)
-                if value:
-                    value = "true" if value == attribute else value
-                    element.set(data_attribute, value)
-                    if aria_attribute:
-                        element.set(aria_attribute, value)
-
-        # 'pattern' attribute for <input> elements
-        handle_attribute(["input"], "pattern", "data-qpy_pattern")
-
-        # 'required' attribute for <input>, <select>, <textarea> elements
-        handle_attribute(["input", "select", "textarea"], "required", "data-qpy_required", "aria-required")
-
-        # 'minlength'/'maxlength' attribute for <input>, <textarea> elements
-        handle_attribute(["input", "textarea"], "minlength", "data-qpy_minlength")
-        handle_attribute(["input", "textarea"], "maxlength", "data-qpy_maxlength")
-
-        # 'min'/'max' attributes for <input> elements
-        handle_attribute(["input"], "min", "data-qpy_min", "aria-valuemin")
-        handle_attribute(["input"], "max", "data-qpy_max", "aria-valuemax")
 
     def _defuse_buttons(self) -> None:
         """Turns submit and reset buttons into simple buttons without a default action."""

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -6,7 +6,17 @@
     <style>
         :root {
             color-scheme: light dark;
+            --invalid-input-color: red;
+
+            &[data-theme="dark"] {
+                --text-color: white;
+            }
+
+            &[data-theme="light"] {
+                --text-color: black;
+            }
         }
+
         body {
             height: auto; /* Make iframe body grow and shrink with page content. */
             display: flow-root; /* Prevent margin-collapse across bottom boundary. */
@@ -15,11 +25,9 @@
             margin: 0;
             color: var(--text-color);
         }
-        :root[data-theme="dark"] {
-            --text-color: white;
-        }
-        :root[data-theme="light"] {
-            --text-color: black;
+
+        :is(input, select, textarea):invalid {
+            border-color: var(--invalid-input-color);
         }
     </style>
 {% endblock %}

--- a/tests/questionpy_sdk/webserver/controllers/attempt/test_question_ui.py
+++ b/tests/questionpy_sdk/webserver/controllers/attempt/test_question_ui.py
@@ -8,14 +8,7 @@ from typing import Any
 import pytest
 from lxml import etree
 
-from questionpy_sdk.webserver_legacy.question_ui import (
-    DisplayRole,
-    QuestionDisplayOptions,
-    QuestionFormulationUIRenderer,
-    QuestionMetadata,
-    QuestionUIRenderer,
-)
-from questionpy_sdk.webserver_legacy.question_ui.errors import (
+from questionpy_sdk.webserver.controllers.attempt.errors import (
     ConversionError,
     DuplicateNameError,
     ExpectedAncestorError,
@@ -27,6 +20,13 @@ from questionpy_sdk.webserver_legacy.question_ui.errors import (
     UnknownAttributeError,
     UnknownElementError,
     XMLSyntaxError,
+)
+from questionpy_sdk.webserver.controllers.attempt.question_ui import (
+    DisplayRole,
+    QuestionDisplayOptions,
+    QuestionFormulationUIRenderer,
+    QuestionMetadata,
+    QuestionUIRenderer,
 )
 
 
@@ -277,26 +277,6 @@ def test_should_disable_inputs(renderer: QuestionUIRenderer) -> None:
             <input class="btn btn-primary qpy-input" name="button_2" type="button" value="value2" disabled="disabled"/>
 
             <textarea class="form-control qpy-input" name="my_textarea" disabled="disabled">original</textarea>
-        </div>
-    """
-    html, errors = renderer.render()
-    assert len(errors) == 0
-    assert_html_is_equal(html, expected)
-
-
-@pytest.mark.ui_file("validations")
-def test_should_soften_validations(renderer: QuestionUIRenderer) -> None:
-    expected = """
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <input class="form-control qpy-input" data-qpy_required="true" aria-required="true"/>
-            <input class="form-control qpy-input" data-qpy_pattern="^[a-z]+$"/>
-            <input class="form-control qpy-input" data-qpy_minlength="5"/>
-            <input class="form-control qpy-input" data-qpy_minlength="10"/>
-            <input class="form-control qpy-input" data-qpy_min="17" aria-valuemin="17"/>
-            <input class="form-control qpy-input" data-qpy_max="42" aria-valuemax="42"/>
-            <input class="form-control qpy-input" data-qpy_pattern="^[a-z]+$" data-qpy_required="true"
-                aria-required="true" data-qpy_minlength="5" data-qpy_maxlength="10" data-qpy_min="17"
-                aria-valuemin="17" data-qpy_max="42" aria-valuemax="42"/>
         </div>
     """
     html, errors = renderer.render()


### PR DESCRIPTION
Anders als im [Plugin](https://github.com/questionpy-org/moodle-qtype_questionpy/pull/184) verwendet das Attempt-Ui im SDK noch kein Bootstrap. Das wollte ich nicht mal eben so ändern, ohne mit @tumidi zu sprechen, daher ist die "Implementierung" hier erstmal trivial, invalide Elemente werden einfach rot umrandet. Die validation message zeigt der Browser ohnehin beim drüberhovern an. 

Wir sollten der Frage mittelfristig noch irgendeine Art von Styling verpassen, das können wir dann ja in 2 Wochen besprechen ;)

Closes: #184 