### PR TITLE
refactor: reuse package ignore logic in `Watcher`, simplify web server integration

### DIFF
--- a/questionpy_sdk/package/errors.py
+++ b/questionpy_sdk/package/errors.py
@@ -3,9 +3,13 @@
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
 
-class PackageSourceValidationError(Exception):
-    pass
+class PackageError(Exception):
+    """Base class for errors related to packaging."""
 
 
-class PackageBuildError(Exception):
-    pass
+class PackageSourceValidationError(PackageError):
+    """Raised when package source files are invalid or fail validation."""
+
+
+class PackageBuildError(PackageError):
+    """Raised when a package fails to build correctly."""

--- a/questionpy_sdk/watcher.py
+++ b/questionpy_sdk/watcher.py
@@ -4,15 +4,17 @@
 
 import asyncio
 import logging
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from pathlib import Path
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Self
 
 from watchdog.events import (
-    FileClosedEvent,
-    FileOpenedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
     FileSystemEvent,
     FileSystemEventHandler,
     FileSystemMovedEvent,
@@ -20,11 +22,12 @@ from watchdog.events import (
 from watchdog.observers import Observer
 from watchdog.utils.event_debouncer import EventDebouncer
 
-from questionpy_common.constants import DIST_DIR
+from questionpy_sdk.package._helper import create_ignore_file_callable
 from questionpy_sdk.package.builder import DirPackageBuilder
-from questionpy_sdk.package.errors import PackageBuildError, PackageSourceValidationError
+from questionpy_sdk.package.errors import PackageError
 from questionpy_sdk.package.source import PackageSource
 from questionpy_sdk.webserver import WebServer
+from questionpy_server.worker.runtime.messages import BaseWorkerError
 from questionpy_server.worker.runtime.package_location import DirPackageLocation
 
 if TYPE_CHECKING:
@@ -36,17 +39,19 @@ _DEBOUNCE_INTERVAL = 1  # seconds
 
 
 class _EventHandler(FileSystemEventHandler):
-    """Debounces events for watchdog file monitoring, ignoring events in the `dist` directory."""
+    """Handles filesystem events with debouncing and ignores paths based on a provided filter."""
 
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
-        notify_callback: Callable[[], Coroutine[Any, Any, None]],
+        notify_callback: Callable[[], None],
         watch_path: Path,
+        ignore_path: Callable[[Path], bool],
     ) -> None:
         self._loop = loop
         self._notify_callback = notify_callback
         self._watch_path = watch_path
+        self._ignore_path = ignore_path
 
         self._event_debouncer = EventDebouncer(_DEBOUNCE_INTERVAL, self._on_file_changes)
 
@@ -65,7 +70,7 @@ class _EventHandler(FileSystemEventHandler):
 
     def _on_file_changes(self, events: list[FileSystemEvent]) -> None:
         # skip synchronization hassle by delegating this to the event loop in the main thread
-        asyncio.run_coroutine_threadsafe(self._notify_callback(), self._loop)
+        self._loop.call_soon_threadsafe(self._notify_callback)
 
     def _ignore_event(self, event: FileSystemEvent) -> bool:
         """Ignores events that should not trigger a rebuild.
@@ -76,18 +81,15 @@ class _EventHandler(FileSystemEventHandler):
         Returns:
             `True` if event should be ignored, otherwise `False`.
         """
-        if isinstance(event, FileOpenedEvent | FileClosedEvent):
+        # only consider file modification events
+        if not isinstance(event, FileDeletedEvent | FileModifiedEvent | FileCreatedEvent | FileMovedEvent):
             return True
 
-        # ignore events events in `dist` dir
-        relevant_path = event.dest_path if isinstance(event, FileSystemMovedEvent) else event.src_path
-        if isinstance(relevant_path, bytes):
-            relevant_path = relevant_path.decode()
+        # for move events we want to look at dest_path
+        path_str_or_bytes = event.dest_path if isinstance(event, FileSystemMovedEvent) else event.src_path
+        path_str = path_str_or_bytes.decode() if isinstance(path_str_or_bytes, bytes) else path_str_or_bytes
 
-        try:
-            return Path(relevant_path).relative_to(self._watch_path).parts[0] == DIST_DIR
-        except IndexError:
-            return False
+        return self._ignore_path(Path(path_str).relative_to(self._watch_path))
 
 
 class Watcher(AbstractAsyncContextManager):
@@ -98,14 +100,18 @@ class Watcher(AbstractAsyncContextManager):
     ) -> None:
         self._source_path = source_path
         self._pkg_location = pkg_location
+        self._state_storage_path = state_storage_path
         self._host = host
         self._port = port
 
-        self._event_handler = _EventHandler(asyncio.get_running_loop(), self._notify, self._source_path)
+        self._file_change = asyncio.Event()
         self._observer = Observer()
-        self._webserver = WebServer(self._pkg_location, state_storage_path, self._host, self._port)
-        self._on_change_event = asyncio.Event()
         self._watch: ObservedWatch | None = None
+
+        additional_ignores = [*PackageSource(source_path).config.ignore, ".gitignore"]
+        ignore_file = create_ignore_file_callable(source_path, additional_ignores)
+        loop = asyncio.get_running_loop()
+        self._event_handler = _EventHandler(loop, self._file_change.set, self._source_path, ignore_file)
 
     async def __aenter__(self) -> Self:
         self._event_handler.start()
@@ -120,11 +126,11 @@ class Watcher(AbstractAsyncContextManager):
         if self._observer.is_alive():
             self._observer.stop()
         self._event_handler.stop()
-        await self._webserver.__aexit__(exc_type, exc_value, traceback)
 
     def _schedule(self) -> None:
         if self._watch is None:
             log.debug("Starting file watching...")
+            self._file_change.clear()
             self._watch = self._observer.schedule(self._event_handler, str(self._source_path), recursive=True)
 
     def _unschedule(self) -> None:
@@ -133,50 +139,32 @@ class Watcher(AbstractAsyncContextManager):
             self._observer.unschedule(self._watch)
             self._watch = None
 
-    async def _notify(self) -> None:
-        self._on_change_event.set()
-
     async def run_forever(self) -> None:
-        try:
-            await self._webserver.__aenter__()  # noqa: PLC2801
-        except Exception:
-            log.exception("Failed to start webserver. The exception was:")
-            # When user messed up the their package on initial run, we just bail out.
-            return
-
-        self._schedule()
+        async def wait_for_changes() -> None:
+            log.info("Waiting for file change before attempting to rebuild...")
+            self._schedule()
+            await self._file_change.wait()
 
         while True:
-            await self._on_change_event.wait()
-
-            # Try to rebuild package and restart web server which might fail.
-            self._unschedule()
-            await self._rebuild_and_restart()
+            # Run web server
             self._schedule()
+            try:
+                async with WebServer(self._pkg_location, self._state_storage_path, self._host, self._port):
+                    await self._file_change.wait()
+            except BaseWorkerError:
+                log.exception("Failed to start web server.")
+                await wait_for_changes()
 
-            self._on_change_event.clear()
-
-    async def _rebuild_and_restart(self) -> None:
-        log.info("File changes detected. Rebuilding package...")
-
-        # Stop webserver.
-        try:
-            await self._webserver.__aexit__(None, None, None)
-        except Exception:
-            log.exception("Failed to stop web server. The exception was:")
-            raise  # Should not happen, thus we're propagating.
-
-        # Build package.
-        try:
-            package_source = PackageSource(self._source_path)
-            with DirPackageBuilder(package_source) as builder:
-                builder.write_package()
-        except (PackageBuildError, PackageSourceValidationError):
-            log.exception("Failed to build package. The exception was:")
-            return
-
-        # Start server.
-        try:
-            await self._webserver.__aenter__()  # noqa: PLC2801
-        except Exception:
-            log.exception("Failed to start web server. The exception was:")
+            # Rebuild package
+            while True:
+                self._unschedule()
+                log.info("File change detected. Rebuilding package...")
+                try:
+                    package_source = PackageSource(self._source_path)
+                    with DirPackageBuilder(package_source) as builder:
+                        builder.write_package()
+                except PackageError:
+                    log.exception("Failed to build package.")
+                    await wait_for_changes()
+                else:
+                    break

--- a/questionpy_sdk/watcher.py
+++ b/questionpy_sdk/watcher.py
@@ -85,11 +85,14 @@ class _EventHandler(FileSystemEventHandler):
         if not isinstance(event, FileDeletedEvent | FileModifiedEvent | FileCreatedEvent | FileMovedEvent):
             return True
 
-        # for move events we want to look at dest_path
-        path_str_or_bytes = event.dest_path if isinstance(event, FileSystemMovedEvent) else event.src_path
-        path_str = path_str_or_bytes.decode() if isinstance(path_str_or_bytes, bytes) else path_str_or_bytes
+        # for move events we need to consider both, `src_path` and `dest_path`
+        check_paths = {event.src_path, event.dest_path} if isinstance(event, FileSystemMovedEvent) else {event.src_path}
 
-        return self._ignore_path(Path(path_str).relative_to(self._watch_path))
+        return all(self._ignore_path(self._get_rel_path(path)) for path in check_paths)
+
+    def _get_rel_path(self, path: bytes | str) -> Path:
+        path_str = path.decode() if isinstance(path, bytes) else path
+        return Path(path_str).relative_to(self._watch_path)
 
 
 class Watcher(AbstractAsyncContextManager):

--- a/tests/questionpy_sdk/test_watcher.py
+++ b/tests/questionpy_sdk/test_watcher.py
@@ -2,59 +2,46 @@
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
 
+import asyncio
+from collections.abc import AsyncIterable, Iterable
+from itertools import product
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import NamedTuple, cast
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
-from watchdog.events import (
-    DirCreatedEvent,
-    DirDeletedEvent,
-    DirModifiedEvent,
-    DirMovedEvent,
-    FileClosedEvent,
-    FileCreatedEvent,
-    FileDeletedEvent,
-    FileModifiedEvent,
-    FileMovedEvent,
-    FileOpenedEvent,
-    FileSystemEvent,
-)
+from watchdog import events as we
 
-from questionpy_common.constants import DIST_DIR
-from questionpy_sdk.watcher import _EventHandler
-
-if TYPE_CHECKING:
-    import asyncio
+from questionpy_sdk.package.errors import PackageBuildError
+from questionpy_sdk.watcher import Watcher, _EventHandler
+from questionpy_server.worker.runtime.messages import WorkerUnknownError
 
 some_path = Path("/", "path", "to")
 
 
 @pytest.fixture
 def event_handler() -> _EventHandler:
-    async def notify() -> None:
-        pass
-
     mock_loop = cast("asyncio.AbstractEventLoop", None)
-    return _EventHandler(mock_loop, notify, some_path)
+
+    def ignore_path(path: Path) -> bool:
+        return bool(path.parts and path.parts[0] == "ignopath")
+
+    return _EventHandler(mock_loop, lambda: None, some_path, ignore_path)
 
 
 @pytest.mark.parametrize(
     "event",
     [
-        DirCreatedEvent(src_path=str(some_path / "foo")),
-        DirDeletedEvent(src_path=str(some_path / "foo")),
-        DirModifiedEvent(src_path=str(some_path / "foo")),
-        DirMovedEvent(src_path=str(some_path / DIST_DIR / "foo"), dest_path=str(some_path / "foo")),
-        FileCreatedEvent(src_path=str(some_path / "foo")),
-        FileCreatedEvent(src_path=str(some_path / "python" / "foo" / "bar" / "module.py")),
-        FileDeletedEvent(src_path=str(some_path / "foo")),
-        FileDeletedEvent(src_path=str(some_path / "python" / "foo" / "bar" / "module.py")),
-        FileModifiedEvent(src_path=str(some_path)),
-        FileModifiedEvent(src_path=str(some_path / "python" / "foo" / "bar" / "module.py")),
-        FileMovedEvent(src_path=str(some_path / DIST_DIR / "foo"), dest_path=str(some_path / "foo")),
+        we.FileCreatedEvent(src_path=str(some_path / "foo")),
+        we.FileCreatedEvent(src_path=str(some_path / "python" / "foo" / "bar" / "module.py")),
+        we.FileDeletedEvent(src_path=str(some_path / "foo")),
+        we.FileDeletedEvent(src_path=str(some_path / "python" / "foo" / "bar" / "module.py")),
+        we.FileModifiedEvent(src_path=str(some_path)),
+        we.FileModifiedEvent(src_path=str(some_path / "python" / "foo" / "bar" / "module.py")),
+        we.FileMovedEvent(src_path=str(some_path / "ignopath" / "foo"), dest_path=str(some_path / "foo")),
     ],
 )
-def test_should_not_ignore_events(event: FileSystemEvent, event_handler: _EventHandler) -> None:
+def test_event_handler_should_not_ignore(event: we.FileSystemEvent, event_handler: _EventHandler) -> None:
     assert not event_handler._ignore_event(event)
 
 
@@ -62,17 +49,107 @@ def test_should_not_ignore_events(event: FileSystemEvent, event_handler: _EventH
 @pytest.mark.parametrize(
     "event",
     [
-        DirCreatedEvent(src_path=str(some_path / DIST_DIR / "foo")),
-        DirDeletedEvent(src_path=str(some_path / DIST_DIR / "foo")),
-        DirModifiedEvent(src_path=str(some_path / DIST_DIR / "foo")),
-        FileClosedEvent(src_path=str(some_path / "foo")),
-        DirMovedEvent(src_path=str(some_path / "foo"), dest_path=str(some_path / DIST_DIR / "foo")),
-        FileCreatedEvent(src_path=str(some_path / DIST_DIR / "foo")),
-        FileDeletedEvent(src_path=str(some_path / DIST_DIR / "foo")),
-        FileModifiedEvent(src_path=str(some_path / DIST_DIR)),
-        FileMovedEvent(src_path=str(some_path / "foo"), dest_path=str(some_path / DIST_DIR / "foo")),
-        FileOpenedEvent(src_path=str(some_path / "foo")),
+        we.FileClosedEvent(src_path=str(some_path / "foo")),
+        we.FileCreatedEvent(src_path=str(some_path / "ignopath" / "foo")),
+        we.FileDeletedEvent(src_path=str(some_path / "ignopath" / "foo")),
+        we.FileModifiedEvent(src_path=str(some_path / "ignopath")),
+        we.FileMovedEvent(src_path=str(some_path / "foo"), dest_path=str(some_path / "ignopath" / "foo")),
+        we.FileOpenedEvent(src_path=str(some_path / "foo")),
     ],
 )
-def test_should_ignore_events(event: FileSystemEvent, event_handler: _EventHandler) -> None:
+def test_event_handler_should_ignore(event: we.FileSystemEvent, event_handler: _EventHandler) -> None:
     assert event_handler._ignore_event(event)
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        we.DirCreatedEvent(src_path=str(some_path / "foo")),
+        we.DirDeletedEvent(src_path=str(some_path / "foo")),
+        we.DirModifiedEvent(src_path=str(some_path / "foo")),
+        we.DirMovedEvent(src_path=str(some_path / "ignopath" / "foo"), dest_path=str(some_path / "foo")),
+    ],
+)
+def test_event_handler_should_ignore_dirs(event: we.FileSystemEvent, event_handler: _EventHandler) -> None:
+    assert event_handler._ignore_event(event)
+
+
+class WatchMockSetup(NamedTuple):
+    observer_mock: Mock
+    event_handler_mock: Mock
+    webserver_mock: AsyncMock
+    package_builder_mock: MagicMock
+
+
+@pytest.fixture
+def watcher_mock_setup(monkeypatch: pytest.MonkeyPatch) -> Iterable[WatchMockSetup]:
+    with monkeypatch.context() as mp:
+        observer_mock = Mock()
+        event_handler_mock = Mock()
+        webserver_mock = AsyncMock()
+        package_source_mock = Mock()
+        ignore_mock = MagicMock()
+        ignore_mock.iter.return_value = iter([])
+        package_source_mock.config.ignore = ignore_mock
+        package_builder_mock = MagicMock()
+        mp.setattr("questionpy_sdk.watcher.Observer", Mock(return_value=observer_mock))
+        mp.setattr("questionpy_sdk.watcher._EventHandler", Mock(return_value=event_handler_mock))
+        mp.setattr("questionpy_sdk.watcher.WebServer", Mock(return_value=webserver_mock))
+        mp.setattr("questionpy_sdk.watcher.PackageSource", Mock(return_value=package_source_mock))
+        mp.setattr("questionpy_sdk.watcher.DirPackageBuilder", Mock(return_value=package_builder_mock))
+
+        yield WatchMockSetup(observer_mock, event_handler_mock, webserver_mock, package_builder_mock)
+
+
+@pytest.fixture
+async def watcher(watcher_mock_setup: WatchMockSetup) -> AsyncIterable[Watcher]:
+    async with Watcher(Path("source"), Mock(), Path("storage"), "localhost", 1234) as watcher:
+        try:
+            task = asyncio.create_task(watcher.run_forever())
+            await asyncio.sleep(0)
+            yield watcher
+        finally:
+            if not task.done():
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+
+async def test_watcher_lifecycle(watcher_mock_setup: WatchMockSetup) -> None:
+    observer_mock, event_handler_mock, _, _ = watcher_mock_setup
+
+    async with Watcher(Path("source"), Mock(), Path("storage"), "localhost", 1234):
+        observer_mock.start.assert_called_once()
+        event_handler_mock.start.assert_called_once()
+
+    observer_mock.stop.assert_called_once()
+    event_handler_mock.stop.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("server_crash", "build_error"),
+    # Combinations of boolean value pairs
+    product((False, True), repeat=2),
+)
+async def test_watcher_run_loop(
+    server_crash: bool, build_error: bool, watcher_mock_setup: WatchMockSetup, watcher: Watcher
+) -> None:
+    _, _, webserver_mock, package_builder_mock = watcher_mock_setup
+
+    if server_crash:
+        webserver_mock.__aenter__.side_effect = WorkerUnknownError(worker_name="mock")
+    if build_error:
+        package_builder_mock.__enter__.side_effect = PackageBuildError()
+
+    webserver_runs = 1
+    for build_runs in range(3):
+        assert webserver_mock.__aenter__.call_count == webserver_runs
+        assert package_builder_mock.__enter__.call_count == build_runs
+
+        # Web server doesn't restart when the package build errors
+        if not build_error:
+            webserver_runs += 1
+
+        # Simulate file change
+        watcher._file_change.set()
+        await asyncio.sleep(0)

--- a/tests/questionpy_sdk/test_watcher.py
+++ b/tests/questionpy_sdk/test_watcher.py
@@ -39,13 +39,14 @@ def event_handler() -> _EventHandler:
         we.FileModifiedEvent(src_path=str(some_path)),
         we.FileModifiedEvent(src_path=str(some_path / "python" / "foo" / "bar" / "module.py")),
         we.FileMovedEvent(src_path=str(some_path / "ignopath" / "foo"), dest_path=str(some_path / "foo")),
+        we.FileMovedEvent(src_path=str(some_path / "foo"), dest_path=str(some_path / "ignopath" / "foo")),
+        we.FileMovedEvent(src_path=str(some_path / "foo"), dest_path=str(some_path / "bar")),
     ],
 )
 def test_event_handler_should_not_ignore(event: we.FileSystemEvent, event_handler: _EventHandler) -> None:
     assert not event_handler._ignore_event(event)
 
 
-# test that the watcher is ignoring certain events, like moving a file into the `dist` folder
 @pytest.mark.parametrize(
     "event",
     [
@@ -53,8 +54,8 @@ def test_event_handler_should_not_ignore(event: we.FileSystemEvent, event_handle
         we.FileCreatedEvent(src_path=str(some_path / "ignopath" / "foo")),
         we.FileDeletedEvent(src_path=str(some_path / "ignopath" / "foo")),
         we.FileModifiedEvent(src_path=str(some_path / "ignopath")),
-        we.FileMovedEvent(src_path=str(some_path / "foo"), dest_path=str(some_path / "ignopath" / "foo")),
         we.FileOpenedEvent(src_path=str(some_path / "foo")),
+        we.FileMovedEvent(src_path=str(some_path / "ignopath" / "foo"), dest_path=str(some_path / "ignopath" / "bar")),
     ],
 )
 def test_event_handler_should_ignore(event: we.FileSystemEvent, event_handler: _EventHandler) -> None:


### PR DESCRIPTION
Dieser PR passt den File Watcher an, so dass er
1. nicht die dunder methods (`__aenter__`/`__aexit__`) des Webservers direkt aufruft, sondern den context manager mit `async with ...` nutzt (siehe e23a8687fd58b4f557a022153d7890cd4cacc8bc) und
2. die neue File-Ignore-Logik des SDKs verwendet (siehe 61bd16312155543db525a7eb200ae4c7df1b62c1).

Außerdem noch Tests für die `Watcher`-Klasse.