### PR TITLE
Coverage tuning/E2E docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,23 @@ The SDK also executes question packages and provides their runtime.
 ```shell
 $ questionpy-sdk run example.qpy
 ```
+
+## E2E Tests
+
+Run a specific test inside Playwright inspector.
+
+```sh
+$ PWDEBUG=1 ./run_e2e_tests.sh -k test_smoke
+```
+
+Generate tests with the Playwright Inspector.
+
+```sh
+$ playwright codegen http://127.0.0.1:8080
+```
+
+Replay a trace, e.g. from a failed CI run artifact.
+
+```sh
+$ playwright show-trace /path/to/trace.zip
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ asyncio_default_fixture_loop_scope = "module"
 [tool.coverage.run]
 branch = true
 source = ["questionpy", "questionpy_sdk"]
+omit = ["questionpy_sdk/webserver/middlewares/vite_dev.py"]
+
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
 
 [tool.mypy]
 plugins = "pydantic.mypy"


### PR DESCRIPTION
- Exkludiert static type checker und Dev-Code vom coverage reporting.
- Abschnitt zu E2E (Playwright) zur `README.md` hinzufügen.