### PR TITLE
Kleinere Refaktorisierung `useOptionsFormDataStore`

### DIFF
--- a/frontend/src/components/PackageCard.vue
+++ b/frontend/src/components/PackageCard.vue
@@ -52,9 +52,9 @@
 </template>
 
 <script lang="ts" setup>
-import useManifest from '@/queries/manifest'
+import useManifestQuery from '@/queries/manifest'
 
-const { asyncStatus, manifest, state } = useManifest()
+const { asyncStatus, manifest, state } = useManifestQuery()
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/queries/attempt.ts
+++ b/frontend/src/queries/attempt.ts
@@ -12,7 +12,7 @@ import { attemptDataSchema } from '@/schema/attempt'
 import useDisplayOptionsStore from '@/stores/useDisplayOptionsStore'
 
 /** Get attempt data query. */
-const useAttemptData = defineQuery(() => {
+const useAttemptDataQuery = defineQuery(() => {
     const { cacheKey, displayOptions } = storeToRefs(useDisplayOptionsStore())
 
     return useQuery({
@@ -28,7 +28,7 @@ const useAttemptData = defineQuery(() => {
 })
 
 /** Save attempt query. */
-const usePostAttempt = defineMutation(() => {
+const usePostAttemptQuery = defineMutation(() => {
     const queryCache = useQueryCache()
     return useMutation({
         mutation: (formData: Record<string, unknown>) => post('attempt', JSON.stringify(formData)),
@@ -37,7 +37,7 @@ const usePostAttempt = defineMutation(() => {
 })
 
 /** Restart attempt query. */
-const usePostAttemptRestart = defineMutation(() => {
+const usePostAttemptRestartQuery = defineMutation(() => {
     const queryCache = useQueryCache()
     return useMutation({
         mutation: () => post('attempt/restart'),
@@ -46,7 +46,7 @@ const usePostAttemptRestart = defineMutation(() => {
 })
 
 /** Score attempt query. */
-const usePostAttemptScore = defineMutation(() => {
+const usePostAttemptScoreQuery = defineMutation(() => {
     const queryCache = useQueryCache()
     return useMutation({
         mutation: () => post('attempt/score'),
@@ -54,4 +54,4 @@ const usePostAttemptScore = defineMutation(() => {
     })
 })
 
-export { useAttemptData, usePostAttempt, usePostAttemptRestart, usePostAttemptScore }
+export { useAttemptDataQuery, usePostAttemptQuery, usePostAttemptRestartQuery, usePostAttemptScoreQuery }

--- a/frontend/src/queries/manifest.ts
+++ b/frontend/src/queries/manifest.ts
@@ -12,7 +12,7 @@ import { manifestSchema } from '@/schema/manifest'
 import { get } from './fetch'
 
 /** Package manifest query. */
-const useManifest = defineQuery(() => {
+const useManifestQuery = defineQuery(() => {
     const query = useQuery({
         key: ['manifest'],
         query: () => get('manifest', manifestSchema),
@@ -36,4 +36,4 @@ const useManifest = defineQuery(() => {
     return { manifest, ...query }
 })
 
-export default useManifest
+export default useManifestQuery

--- a/frontend/src/queries/options.ts
+++ b/frontend/src/queries/options.ts
@@ -18,7 +18,7 @@ import { optionsFormDataSchema, optionsSchema } from '@/schema/options'
 import type { Options, OptionsFormData, ServerValidationErrors } from '@/schema/options/types'
 
 /** Get options form data query. */
-const useOptionsFormData = defineQuery(() =>
+const useOptionsFormDataQuery = defineQuery(() =>
     useQuery({
         key: ['options', 'data'],
         query: () => get('options/state', optionsFormDataSchema),
@@ -65,4 +65,4 @@ const usePostOptionsFormData = defineMutation(() => {
     return { ...mutation, onSuccess }
 })
 
-export { useOptionsFormData, useOptionsFormDefinition, usePostOptionsFormData }
+export { useOptionsFormDataQuery, useOptionsFormDefinition, usePostOptionsFormData }

--- a/frontend/src/stores/__tests__/useAppStateStore.test.ts
+++ b/frontend/src/stores/__tests__/useAppStateStore.test.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of the QuestionPy SDK. (https://questionpy.org)
+ * The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+ * (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+
+import useAppStateStore from '@/stores/useAppStateStore'
+
+beforeEach(() => {
+    setActivePinia(createPinia())
+})
+
+test('useAppStateStore.displayPageTitle (null pageTitle)', () => {
+    const store = useAppStateStore()
+    store.pageTitle = null
+    expect(store.displayPageTitle).toBe('QuestionPy SDK')
+})
+
+test('useAppStateStore.displayPageTitle (set pageTitle)', () => {
+    const store = useAppStateStore()
+    store.pageTitle = 'Test Page'
+    expect(store.displayPageTitle).toBe('QuestionPy SDK - Test Page')
+})
+
+test('useAppStateStore.setError (with Error instance)', () => {
+    const store = useAppStateStore()
+    const error = new Error('Test error')
+    store.setError(error)
+    expect(store.currentError).toBe(error)
+})
+
+test('useAppStateStore.setError (with non-Error instance)', () => {
+    const store = useAppStateStore()
+    store.setError('Not an error')
+    expect(store.currentError).toBeNull()
+})
+
+test('useAppStateStore.clearError (resets error)', () => {
+    const store = useAppStateStore()
+    store.currentError = new Error('Test')
+    store.clearError()
+    expect(store.currentError).toBeNull()
+})

--- a/frontend/src/stores/useAttemptStore.ts
+++ b/frontend/src/stores/useAttemptStore.ts
@@ -7,17 +7,22 @@
 import { defineStore } from 'pinia'
 import { computed, onUnmounted } from 'vue'
 
-import { useAttemptData, usePostAttempt, usePostAttemptRestart, usePostAttemptScore } from '@/queries/attempt'
+import {
+    useAttemptDataQuery,
+    usePostAttemptQuery,
+    usePostAttemptRestartQuery,
+    usePostAttemptScoreQuery,
+} from '@/queries/attempt'
 import { usePostOptionsFormData } from '@/queries/options'
 
 import useAppStateStore from './useAppStateStore'
 
 /** Provides attempt data. */
 const useAttemptStore = defineStore('attemptData', () => {
-    const { asyncStatus: dataAsyncStatus, state: dataState, refresh: dataRefresh } = useAttemptData()
-    const { asyncStatus: postAsyncStatus, mutateAsync: postAttempt } = usePostAttempt()
-    const { asyncStatus: postRestartAsyncStatus, mutateAsync: postRestart } = usePostAttemptRestart()
-    const { asyncStatus: postScoreAsyncStatus, mutateAsync: postScore } = usePostAttemptScore()
+    const { asyncStatus: dataAsyncStatus, state: dataState, refresh: dataRefresh } = useAttemptDataQuery()
+    const { asyncStatus: postAsyncStatus, mutateAsync: postAttempt } = usePostAttemptQuery()
+    const { asyncStatus: postRestartAsyncStatus, mutateAsync: postRestart } = usePostAttemptRestartQuery()
+    const { asyncStatus: postScoreAsyncStatus, mutateAsync: postScore } = usePostAttemptScoreQuery()
     const { onSuccess: onPostOptionsFormDataSuccess } = usePostOptionsFormData()
 
     const { setError } = useAppStateStore()

--- a/frontend/src/stores/useOptionsFormDataStore/index.ts
+++ b/frontend/src/stores/useOptionsFormDataStore/index.ts
@@ -5,211 +5,32 @@
  */
 
 import { defineStore } from 'pinia'
-import { computed, ref, toRaw, watch } from 'vue'
+import { computed } from 'vue'
 
-import { useAttemptData } from '@/queries/attempt'
-import { useOptionsFormData, useOptionsFormDefinition, usePostOptionsFormData } from '@/queries/options'
-import type { FormElement, OptionsFormData, OptionsFormDataValue, ServerValidationErrors } from '@/schema/options/types'
+import { useOptionsFormDataQuery, useOptionsFormDefinition, usePostOptionsFormData } from '@/queries/options'
 
-import {
-    areFormDataObjIdentical,
-    createFormDataValues,
-    getElementName,
-    getErrorKey,
-    getFormData,
-    hasEditableElements,
-} from './formDataUtils'
+import useFormDataState from './useFormDataState'
 
 /** Provides options form definition and manages form data. */
 const useOptionsFormDataStore = defineStore('optionsFormData', () => {
     const { asyncStatus: definitionAsyncStatus, state: definitionState } = useOptionsFormDefinition()
-    const { asyncStatus: dataAsyncStatus, state: dataState, refresh: dataRefresh } = useOptionsFormData()
-    const { asyncStatus: postDataAsyncStatus, mutateAsync: postData, state: mutationState } = usePostOptionsFormData()
-    const { state: attemptDataState } = useAttemptData()
+    const { asyncStatus: dataAsyncStatus, state: dataState } = useOptionsFormDataQuery()
+    const { asyncStatus: postDataAsyncStatus, state: mutationState } = usePostOptionsFormData()
 
-    const formData = ref<OptionsFormData>({})
-    const formDataClean = ref<OptionsFormData>({})
-    const formErrors = ref<ServerValidationErrors>({})
-
-    watch([() => definitionState.value.status, () => dataState.value.status], ([definitionStatus, dataStatus]) => {
-        if (
-            definitionStatus === 'success' &&
-            dataStatus === 'success' &&
-            definitionState.value.data &&
-            dataState.value.data
-        ) {
-            // Restore form data and populate with default values
-            formData.value = getFormData(definitionState.value.data, dataState.value.data)
-            // Remember clean form state
-            formDataClean.value = structuredClone(toRaw(formData.value))
-        }
-    })
-
-    /**
-     * Gets number of repetitions for a repetition element.
-     *
-     * @param path The path representing the repetition element.
-     * @returns The number of repetitions.
-     */
-    function getRepetitionCount(path: string[]): number {
-        // There's no explicit value in the data model, so we need to derive it from the form data.
-        const re = new RegExp(`^${RegExp.escape(getElementName(path))}\\[(\\d+)\\]`)
-        let highest = 0
-        for (const elName of Object.keys(formData.value)) {
-            const match = re.exec(elName)
-            if (match) {
-                highest = Math.max(highest, Number(match[1]))
-            }
-        }
-        return highest
-    }
-
-    const hasAttemptState = computed(() => attemptDataState.value.data !== undefined)
-    const hasEditableFields = computed(
-        () =>
-            hasEditableElements(definitionState.value.data?.general ?? []) ||
-            (definitionState.value.data?.sections ?? []).some((section) => hasEditableElements(section.elements)),
+    const asyncStatus = computed(() =>
+        [definitionAsyncStatus, dataAsyncStatus, postDataAsyncStatus].some((status) => status.value === 'loading')
+            ? 'loading'
+            : 'idle',
     )
-
-    const isClean = computed(() => areFormDataObjIdentical(formData.value, formDataClean.value))
-    const isSaving = computed(() => postDataAsyncStatus.value !== 'idle')
-
-    const isSaveDisabled = computed(() => isClean.value || isSaving.value)
-    const isPreviewDisabled = computed(
-        () => isSaving.value || (!hasAttemptState.value && isClean.value) || Object.keys(formErrors.value).length > 0,
-    )
+    const error = computed(() => definitionState.value.error ?? dataState.value.error ?? mutationState.value.error)
+    const formDefinition = computed(() => definitionState.value.data)
 
     return {
-        asyncStatus: computed(() =>
-            definitionAsyncStatus.value === 'idle' && dataAsyncStatus.value === 'idle' ? 'idle' : 'loading',
-        ),
-        error: computed(() => definitionState.value.error ?? dataState.value.error ?? mutationState.value.error),
+        asyncStatus,
+        error,
+        formDefinition,
 
-        hasEditableFields,
-        isClean,
-        isPreviewDisabled,
-        isSaveDisabled,
-        isSaving,
-
-        formDefinition: computed(() => definitionState.value.data),
-        formData,
-        formErrors,
-
-        /**
-         * Submits the form data.
-         *
-         * @returns `false` if form has validation errors, otherwise `true`.
-         */
-        async submit(): Promise<boolean> {
-            const rawFormData = toRaw(formData.value)
-            try {
-                formErrors.value = await postData(rawFormData)
-            } catch (err) {
-                if (err instanceof Error) {
-                    mutationState.value.error = err
-                }
-                throw err
-            }
-            formDataClean.value = structuredClone(rawFormData)
-            mutationState.value.error = null
-            await dataRefresh()
-            return Object.keys(formErrors.value).length === 0
-        },
-
-        /** Resets the form data. */
-        reset(): void {
-            formData.value = structuredClone(toRaw(formDataClean.value))
-        },
-
-        /**
-         * Retrieves a value from the form data object.
-         *
-         * @param name The name representing the input field, e.g. `general[first_name]`.
-         * @returns The value found at the specified name in the `formData` object, or `undefined` otherwise.
-         */
-        getValue<T extends OptionsFormDataValue>(name: string): T | undefined {
-            if (name in formData.value) {
-                return formData.value[name] as T
-            }
-        },
-
-        /**
-         * Sets a value on the form data object.
-         *
-         * @param name The name representing the input field, e.g. `general[first_name]`.
-         * @param value The value to set at the specified name.
-         */
-        setValue(name: string, value: OptionsFormDataValue): void {
-            formData.value[name] = value
-        },
-
-        /**
-         * Retrieves the validation feedback text of a form element.
-         *
-         * @param path The path representing the element.
-         * @returns The validation feedback text or `undefined`.
-         */
-        getFeedback(path: string[]): string | undefined {
-            return formErrors.value[getErrorKey(path)]
-        },
-
-        /**
-         * Adds another repetition to a repetition element.
-         *
-         * @param path The path representing the repetition element.
-         * @param elements The repetition element's child elements.
-         */
-        addRepetition(path: string[], elements: FormElement[]): void {
-            const count = getRepetitionCount(path) + 1
-            createFormDataValues(formData.value, elements, [...path, count.toString()])
-        },
-
-        /**
-         * Removes a repetition from a repetition element.
-         *
-         * @param path The path representing the repetition element.
-         * @param num The repetition number to be removed.
-         */
-        removeRepetition(path: string[], num: number): void {
-            const count = getRepetitionCount(path)
-            const repName = getElementName(path)
-
-            // Delete repetition values...
-            let repNameWithNum = `${repName}[${num}]`
-            for (const name of Object.keys(formData.value)) {
-                if (name.startsWith(repNameWithNum)) {
-                    delete formData.value[name]
-                }
-            }
-
-            let errKey = getErrorKey([...path, String(num)])
-            for (const key of Object.keys(formErrors.value)) {
-                if (key.startsWith(errKey)) {
-                    delete formErrors.value[key]
-                }
-            }
-
-            // ...and shift all subsequent by one.
-            for (let i = num + 1; i <= count; ++i) {
-                repNameWithNum = `${repName}[${i}]`
-                for (const [name, value] of Object.entries(formData.value)) {
-                    if (name.startsWith(repNameWithNum)) {
-                        formData.value[name.replace(repNameWithNum, `${repName}[${i - 1}]`)] = value
-                        delete formData.value[name]
-                    }
-                }
-
-                errKey = getErrorKey([...path, String(i)])
-                for (const [key, value] of Object.entries(formErrors.value)) {
-                    if (key.startsWith(errKey)) {
-                        formErrors.value[key.replace(errKey, getErrorKey([...path, String(i - 1)]))] = value
-                        delete formErrors.value[key]
-                    }
-                }
-            }
-        },
-
-        getRepetitionCount,
+        ...useFormDataState(),
     }
 })
 

--- a/frontend/src/stores/useOptionsFormDataStore/useFormDataState.ts
+++ b/frontend/src/stores/useOptionsFormDataStore/useFormDataState.ts
@@ -1,0 +1,139 @@
+/**
+ * This file is part of the QuestionPy SDK. (https://questionpy.org)
+ * The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+ * (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+ */
+
+import { computed, ref, toRaw, watch } from 'vue'
+
+import { useAttemptDataQuery } from '@/queries/attempt'
+import { useOptionsFormDataQuery, useOptionsFormDefinition, usePostOptionsFormData } from '@/queries/options'
+import type { OptionsFormData, OptionsFormDataValue, ServerValidationErrors } from '@/schema/options/types'
+
+import { areFormDataObjIdentical, getErrorKey, getFormData, hasEditableElements } from './formDataUtils'
+import useRepetitions from './useRepetitions'
+
+function useFormDataState() {
+    const { state: definitionState } = useOptionsFormDefinition()
+    const { state: dataState, refresh: dataRefresh } = useOptionsFormDataQuery()
+    const { asyncStatus: postDataAsyncStatus, mutateAsync: postData, state: mutationState } = usePostOptionsFormData()
+    const { state: attemptDataState } = useAttemptDataQuery()
+
+    // Form data
+    const formData = ref<OptionsFormData>({})
+    const formDataClean = ref<OptionsFormData>({})
+
+    // Form validation errors
+    const formErrors = ref<ServerValidationErrors>({})
+
+    // Build form data from server-side state
+    watch([() => definitionState.value.status, () => dataState.value.status], ([definitionStatus, dataStatus]) => {
+        if (
+            definitionStatus === 'success' &&
+            dataStatus === 'success' &&
+            definitionState.value.data &&
+            dataState.value.data
+        ) {
+            // Restore form data and populate with default values
+            formData.value = getFormData(definitionState.value.data, dataState.value.data)
+            // Remember clean form state
+            formDataClean.value = structuredClone(toRaw(formData.value))
+        }
+    })
+
+    // Form logic
+
+    const hasAttemptState = computed(() => attemptDataState.value.data !== undefined)
+    const hasEditableFields = computed(
+        () =>
+            hasEditableElements(definitionState.value.data?.general ?? []) ||
+            (definitionState.value.data?.sections ?? []).some((section) => hasEditableElements(section.elements)),
+    )
+
+    const isClean = computed(() => areFormDataObjIdentical(formData.value, formDataClean.value))
+    const isSaving = computed(() => postDataAsyncStatus.value !== 'idle')
+
+    const isSaveDisabled = computed(() => isClean.value || isSaving.value)
+    const isPreviewDisabled = computed(
+        () => isSaving.value || (!hasAttemptState.value && isClean.value) || Object.keys(formErrors.value).length > 0,
+    )
+
+    /**
+     * Submits the form data.
+     *
+     * @returns `false` if form has validation errors, otherwise `true`.
+     */
+    async function submit(): Promise<boolean> {
+        const rawFormData = toRaw(formData.value)
+        try {
+            formErrors.value = await postData(rawFormData)
+        } catch (err) {
+            if (err instanceof Error) {
+                mutationState.value.error = err
+            }
+            throw err
+        }
+        formDataClean.value = structuredClone(rawFormData)
+        mutationState.value.error = null
+        await dataRefresh()
+        return Object.keys(formErrors.value).length === 0
+    }
+
+    /** Resets the form data. */
+    function reset(): void {
+        formData.value = structuredClone(toRaw(formDataClean.value))
+    }
+
+    /**
+     * Retrieves a value from the form data object.
+     *
+     * @param name The name representing the input field, e.g. `general[first_name]`.
+     * @returns The value found at the specified name in the `formData` object, or `undefined` otherwise.
+     */
+    function getValue<T extends OptionsFormDataValue>(name: string): T | undefined {
+        if (name in formData.value) {
+            return formData.value[name] as T
+        }
+    }
+
+    /**
+     * Sets a value on the form data object.
+     *
+     * @param name The name representing the input field, e.g. `general[first_name]`.
+     * @param value The value to set at the specified name.
+     */
+    function setValue(name: string, value: OptionsFormDataValue): void {
+        formData.value[name] = value
+    }
+
+    /**
+     * Retrieves the validation feedback text of a form element.
+     *
+     * @param path The path representing the element.
+     * @returns The validation feedback text or `undefined`.
+     */
+    function getFeedback(path: string[]): string | undefined {
+        return formErrors.value[getErrorKey(path)]
+    }
+
+    return {
+        formData,
+        formErrors,
+
+        hasEditableFields,
+        isClean,
+        isPreviewDisabled,
+        isSaveDisabled,
+        isSaving,
+
+        submit,
+        reset,
+        getValue,
+        setValue,
+        getFeedback,
+
+        ...useRepetitions(formData, formErrors),
+    }
+}
+
+export default useFormDataState

--- a/frontend/src/stores/useOptionsFormDataStore/useRepetitions.ts
+++ b/frontend/src/stores/useOptionsFormDataStore/useRepetitions.ts
@@ -1,0 +1,93 @@
+/**
+ * This file is part of the QuestionPy SDK. (https://questionpy.org)
+ * The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
+ * (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
+ */
+
+import type { Ref } from 'vue'
+
+import type { FormElement, OptionsFormData, ServerValidationErrors } from '@/schema/options/types'
+
+import { createFormDataValues, getElementName, getErrorKey } from './formDataUtils'
+
+/** Provides management for form repetitions. */
+function useRepetitions(formData: Ref<OptionsFormData>, formErrors: Ref<ServerValidationErrors>) {
+    /**
+     * Gets number of repetitions for a repetition element.
+     *
+     * @param path The path representing the repetition element.
+     * @returns The number of repetitions.
+     */
+    function getRepetitionCount(path: string[]): number {
+        // There's no explicit value in the data model, so we need to derive it from the form data.
+        const re = new RegExp(`^${RegExp.escape(getElementName(path))}\\[(\\d+)\\]`)
+        let highest = 0
+        for (const elName of Object.keys(formData.value)) {
+            const match = re.exec(elName)
+            if (match) {
+                highest = Math.max(highest, Number(match[1]))
+            }
+        }
+        return highest
+    }
+
+    /**
+     * Adds another repetition to a repetition element.
+     *
+     * @param path The path representing the repetition element.
+     * @param elements The repetition element's child elements.
+     */
+    function addRepetition(path: string[], elements: FormElement[]): void {
+        const count = getRepetitionCount(path) + 1
+        createFormDataValues(formData.value, elements, [...path, count.toString()])
+    }
+
+    /**
+     * Removes a repetition from a repetition element.
+     *
+     * @param path The path representing the repetition element.
+     * @param num The repetition number to be removed.
+     */
+    function removeRepetition(path: string[], num: number): void {
+        const count = getRepetitionCount(path)
+        const repName = getElementName(path)
+
+        // Delete repetition values...
+        let repNameWithNum = `${repName}[${num}]`
+        for (const name of Object.keys(formData.value)) {
+            if (name.startsWith(repNameWithNum)) {
+                delete formData.value[name]
+            }
+        }
+
+        let errKey = getErrorKey([...path, String(num)])
+        for (const key of Object.keys(formErrors.value)) {
+            if (key.startsWith(errKey)) {
+                delete formErrors.value[key]
+            }
+        }
+
+        // ...and shift all subsequent by one.
+        for (let i = num + 1; i <= count; ++i) {
+            repNameWithNum = `${repName}[${i}]`
+            for (const [name, value] of Object.entries(formData.value)) {
+                if (name.startsWith(repNameWithNum)) {
+                    formData.value[name.replace(repNameWithNum, `${repName}[${i - 1}]`)] = value
+                    delete formData.value[name]
+                }
+            }
+
+            errKey = getErrorKey([...path, String(i)])
+            for (const [key, value] of Object.entries(formErrors.value)) {
+                if (key.startsWith(errKey)) {
+                    formErrors.value[key.replace(errKey, getErrorKey([...path, String(i - 1)]))] = value
+                    delete formErrors.value[key]
+                }
+            }
+        }
+    }
+
+    return { addRepetition, getRepetitionCount, removeRepetition }
+}
+
+export default useRepetitions


### PR DESCRIPTION
- `useOptionsFormDataStore` ist mit der Zeit immer größer und unübersichtlicher geworden.
Daher splitte ich den store in kleinere composables auf.
- Außerdem, Umbenennen der query composables, so dass die einheitlich einen `Query`-Appendix haben.
- Ein kleiner Test für `useAppStateStore`.