### PR TITLE
feat: load custom css

### DIFF
--- a/questionpy_sdk/webserver/controllers/attempt/controller.py
+++ b/questionpy_sdk/webserver/controllers/attempt/controller.py
@@ -1,7 +1,7 @@
 #  This file is part of the QuestionPy SDK. (https://questionpy.org)
 #  The QuestionPy SDK is free software released under terms of the MIT license. See LICENSE.md.
 #  (c) Technische Universität Berlin, innoCampus <info@isis.tu-berlin.de>
-
+import logging
 import random
 import re
 from enum import StrEnum
@@ -22,6 +22,10 @@ from .question_ui import QuestionDisplayOptions, QuestionFormulationUIRenderer, 
 
 if TYPE_CHECKING:
     from questionpy_server.worker import Worker
+
+
+_log = logging.getLogger(__name__)
+_QPY_URL_PATTERN = re.compile(r"^qpy://static/([a-z_]\w{0,126})/([a-z_]\w{0,126})((?:/[\w\-@:%+.~=]+)+)$")
 
 
 class AttemptStatus(StrEnum):
@@ -46,6 +50,7 @@ class AttemptTemplateContext(TypedDict):
     display_options: QuestionDisplayOptions
     import_map: dict[str, str]
     javascript_calls: list[JsModuleCall]
+    stylesheet_urls: list[str]
 
 
 @dataclass
@@ -154,6 +159,7 @@ class AttemptController(BaseController):
             "display_options": display_options,
             "import_map": await self._get_import_map(),
             "javascript_calls": self._get_js_calls(attempt, display_options),
+            "stylesheet_urls": self._get_stylesheet_urls(attempt),
         }
 
         render_errors: SectionErrorMap = {}
@@ -198,6 +204,26 @@ class AttemptController(BaseController):
             if (call.if_role is None or call.if_role in display_options.roles)
             and (call.if_feedback_type is None or feedback_map[call.if_feedback_type])
         ]
+
+    def _get_stylesheet_urls(self, attempt: AttemptModel) -> list[str]:
+        urls = []
+
+        for url in set(attempt.ui.css_files):
+            if match := _QPY_URL_PATTERN.match(url):
+                namespace, short_name, path = match.group(1, 2, 3)
+                static_path = f"static{path}"
+                api_url = self.generate_api_url("file", namespace=namespace, short_name=short_name, path=static_path)
+                urls.append(str(api_url))
+                continue
+            if url.startswith("qpy://"):
+                _log.warning("Stylesheet URL '%s' looks like a QPy-URL, but could not be parsed.", url)
+                continue
+            if not url.startswith("https://"):
+                _log.warning("Stylesheet URL '%s' does not use a supported scheme.", url)
+                continue
+            urls.append(url)
+
+        return urls
 
     @property
     def _attempt_template(self) -> jinja2.Template:

--- a/questionpy_sdk/webserver/templates/attempt.html.jinja2
+++ b/questionpy_sdk/webserver/templates/attempt.html.jinja2
@@ -30,6 +30,10 @@
             border-color: var(--invalid-input-color);
         }
     </style>
+
+    {% for stylesheet_url in stylesheet_urls %}
+        <link rel="stylesheet" href="{{ stylesheet_url|safe }}" />
+    {% endfor %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Closes #193 
Basiert auf #197 

Da das SDK noch kein Bootstrap lädt, sind folgende Unterschiede mit dem Truthtable-Paket zu beobachten:
Moodle
![image](https://github.com/user-attachments/assets/d0d81266-fef0-4c41-9bdf-30212fa21ef2)

SDK (Light-Mode)
![image](https://github.com/user-attachments/assets/710fe8ff-983e-445e-95a1-fc43f0e8f186)

SDK (Dark-Mode)
![image](https://github.com/user-attachments/assets/43657090-d074-497d-904f-3a3534d39440)

Interessanterweise verschwinden einige Border, wenn Bootstrap geladen wird.
![image](https://github.com/user-attachments/assets/f2cea287-605b-4ed3-8901-4759fbd27694)
