### PR TITLE
fix(example): do not modify options form

### DIFF
--- a/examples/minimal/python/local/minimal_example/question_type.py
+++ b/examples/minimal/python/local/minimal_example/question_type.py
@@ -1,7 +1,4 @@
-from pydantic import JsonValue
-
 from questionpy import Attempt, Question, ResponseNotScorableError
-from questionpy_common.elements import OptionsFormDefinition
 
 from .form import MyModel
 
@@ -27,8 +24,3 @@ class ExampleQuestion(Question):
     attempt_class = ExampleAttempt
 
     options: MyModel
-
-    def get_options_form(self) -> tuple[OptionsFormDefinition, dict[str, JsonValue]]:
-        form, data = super().get_options_form()
-        data["input"] = 2
-        return form, data


### PR DESCRIPTION
Reverted die Datei-Änderung aus 978a0e26a92e8d31847121e6d9a3225b6e83b0bb 

Ich hatte mich vorhin gewundert, weshalb der Input auf `2` gesetzt wurde, obwohl ich etwas anderes eingegeben habe.
Das wurde vemutlich versehentlich gepusht, oder?