### PR TITLE
Frontend: Ziffern in Feldnamen von Fragen für die Validierung zulassen

### DIFF
--- a/frontend/src/composables/question/formDataUtils.ts
+++ b/frontend/src/composables/question/formDataUtils.ts
@@ -45,7 +45,7 @@ function getErrorKey(path: string[]): string {
             // Remove 'general' prefix
             .slice(path[0] === 'general' ? 1 : 0)
             // Backend validation uses 0-based index
-            .map((part) => (part.match(/\d+/) ? String(Number(part) - 1) : part))
+            .map((part) => (part.match(/^\d+$/) ? String(Number(part) - 1) : part))
             .join('.')
     )
 }


### PR DESCRIPTION
Bisher wurden Validierungsmeldungen für Formularfelder mit Ziffern im Namen nicht angezeigt. Die Regex unterscheidet nun korrekt zwischen rein numerischen und gemischt alphanumerischen Bestandteilen.
