### PR TITLE
Gültige JSON-Antwort zurückliefern

### DIFF
--- a/questionpy_sdk/webserver/routes/attempt.py
+++ b/questionpy_sdk/webserver/routes/attempt.py
@@ -47,7 +47,7 @@ class AttemptView(AttemptBaseView):
 
         data = await self.request.json()
         await self.controller.save_attempt(question_id, attempt_id, data)
-        return web.Response()
+        return self.json_success_response()
 
     async def delete(self) -> web.Response:
         """Deletes the attempt from the state storage."""
@@ -59,7 +59,7 @@ class AttemptView(AttemptBaseView):
         except webserver_errors.MissingAttemptStateError as err:
             raise HTTPNotFound from err
 
-        return web.json_response()
+        return self.json_success_response()
 
 
 @routes.view(f"/question/{{question_id:{ID_RE}}}/attempts", name="attempt.list")
@@ -82,7 +82,7 @@ class AttemptScoreView(AttemptBaseView):
             await self.controller.score_attempt(question_id, attempt_id)
         except webserver_errors.MissingStateError as err:
             raise web.HTTPBadRequest(text=str(err)) from err
-        return web.Response()
+        return self.json_success_response()
 
 
 @routes.view(
@@ -103,4 +103,4 @@ class AttemptCloneView(AttemptBaseView):
         except webserver_errors.DuplicateAttemptError as err:
             raise web.HTTPConflict(text=str(err)) from err
 
-        return web.Response()
+        return self.json_success_response()

--- a/questionpy_sdk/webserver/routes/base.py
+++ b/questionpy_sdk/webserver/routes/base.py
@@ -29,3 +29,7 @@ class BaseView[CT: "BaseController"](web.View):
     def json_model_response(self, model: BaseModel, **kwargs: Any) -> web.Response:
         """Create JSON response from model using Pydantic's serializer."""
         return web.json_response(text=model.model_dump_json(**kwargs))
+
+    def json_success_response(self, msg: str = "Success") -> web.Response:
+        """Create JSON response signalling success."""
+        return web.json_response({"msg": msg})

--- a/questionpy_sdk/webserver/routes/question.py
+++ b/questionpy_sdk/webserver/routes/question.py
@@ -35,7 +35,7 @@ class QuestionView(QuestionBaseView):
         except MissingQuestionStateError as err:
             raise HTTPNotFound from err
 
-        return web.json_response()
+        return self.json_success_response()
 
 
 @routes.view("/questions", name="question.list")
@@ -48,7 +48,7 @@ class QuestionListView(QuestionBaseView):
     async def delete(self) -> web.Response:
         """Deletes all questions and its attempts from the state storage."""
         await self.controller.delete_all_questions()
-        return web.json_response()
+        return self.json_success_response()
 
 
 @routes.view(f"/question/{{question_id:{ID_RE}}}/state", name="question.state")
@@ -69,7 +69,7 @@ class QuestionStateView(QuestionBaseView):
         except OptionsFormValidationError as err:
             return web.json_response(err.errors, status=HTTPUnprocessableEntity.status_code)
 
-        return web.json_response()
+        return self.json_success_response()
 
 
 @routes.view(f"/question/{{question_id:{ID_RE}}}/clone/{{new_question_id:{ID_RE}}}", name="question.clone")
@@ -86,4 +86,4 @@ class QuestionCloneView(QuestionBaseView):
         except DuplicateQuestionError as err:
             raise web.HTTPConflict(text=str(err)) from err
 
-        return web.Response()
+        return self.json_success_response()


### PR DESCRIPTION
Die API-Endpunkte liefern nun immer gültige JSON-Daten zurück.

Hängt ab von #254 